### PR TITLE
Implement v3, update docs, add fillzoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * for consistency, add `TileJSONBuilder::default()` - same as `::new()`
 * Migrate to Rust 2021 edition
 * Remove `serde_json` dependency
+* update docs to match v3.0.0 spec
+* add `fillzoom` field per 3.0.0. spec
 
 <a name="v0.2.4"></a>
 ### v0.2.4 (2021-10-11)

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -1,114 +1,189 @@
 use serde::{Deserialize, Serialize};
 
-/// TileJSON struct that represents map metadata
+/// TileJSON struct represents tilejson-spec metadata as specified by
+/// https://github.com/mapbox/tilejson-spec (version 3.0.0)
+/// Some descriptions were copied verbatim from the spec per CC-BY 3.0 license.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct TileJSON {
-    /// A semver.org style version number. Describes the version of
-    /// the TileJSON spec that is implemented by this JSON object.
+    /// A semver.org style version number as a string.
+    /// Describes the version of the TileJSON spec that is implemented by this JSON object.
+    /// Example: `"3.0.0"`
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#31-tilejson
     pub tilejson: String,
 
     /// The tileset id.
+    ///
+    /// **This field is not part of the TileJSON spec and possibly may need to be deleted.**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    /// A name describing the tileset. The name can
-    /// contain any legal character. Implementations SHOULD NOT interpret the
-    /// name as HTML.
+    /// A name describing the tileset.
+    ///
+    /// The name can contain any legal character.
+    /// Implementations SHOULD NOT interpret the name as HTML.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#314-name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// A text description of the tileset. The
-    /// description can contain any legal character. Implementations SHOULD NOT
-    /// interpret the description as HTML.
+    /// A text description of the set of tiles.
+    ///
+    /// The description can contain any valid unicode character as described by the JSON specification RFC 8259.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#38-description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// A semver.org style version number. When
-    /// changes across tiles are introduced, the minor version MUST change.
-    /// This may lead to cut off labels. Therefore, implementors can decide to
-    /// clean their cache when the minor version changes. Changes to the patch
-    /// level MUST only have changes to tiles that are contained within one tile.
-    /// When tiles change significantly, the major version MUST be increased.
+    /// A semver.org style version number of the tiles.
+    ///
+    /// When changes across tiles are introduced the minor version MUST change.
+    /// This may lead to cut off labels. Therefore, implementors can decide to clean
+    /// their cache when the minor version changes. Changes to the patch level MUST
+    /// only have changes to tiles that are contained within one tile.
+    /// When tiles change significantly, such as updating a vector tile layer name,
+    /// the major version MUST be increased.
     /// Implementations MUST NOT use tiles with different major versions.
+    /// OPTIONAL. String. Default: "1.0.0".
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#317-version
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
-    /// Contains an attribution to be displayed
-    /// when the map is shown to a user. Implementations MAY decide to treat this
-    /// as HTML or literal text. For security reasons, make absolutely sure that
-    /// this field can't be abused as a vector for XSS or beacon tracking.
+    /// Contains an attribution to be displayed when the map is shown to a user.
+    ///
+    /// Implementations MAY decide to treat this as HTML or literal text.
+    /// For security reasons, make absolutely sure that this content
+    /// can't be abused as a vector for XSS or beacon tracking.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#34-attribution
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attribution: Option<String>,
 
-    /// Contains a mustache template to be used to
-    /// format data from grids for interaction.
-    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2
-    /// for the interactivity specification.
+    /// Contains a mustache template to be used to format data from grids for interaction.
+    ///
+    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2 for the interactivity specification.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#316-template
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<String>,
 
     /// Contains a legend to be displayed with the map.
+    ///
     /// Implementations MAY decide to treat this as HTML or literal text.
-    /// For security reasons, make absolutely sure that this field can't be
-    /// abused as a vector for XSS or beacon tracking.
+    /// For security reasons, make absolutely sure that this field
+    /// can't be abused as a vector for XSS or beacon tracking.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#311-legend
     #[serde(skip_serializing_if = "Option::is_none")]
     pub legend: Option<String>,
 
-    /// Either "xyz" or "tms". Influences the y
-    /// direction of the tile coordinates.
+    /// Either "xyz" or "tms".
+    ///
+    /// Influences the y direction of the tile coordinates.
     /// The global-mercator (aka Spherical Mercator) profile is assumed.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#315-scheme
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scheme: Option<String>,
 
-    /// An array of tile endpoints. {z}, {x} and {y}, if present,
-    /// are replaced with the corresponding integers. If multiple endpoints are specified, clients
-    /// may use any combination of endpoints. All endpoints MUST return the same
-    /// content for the same URL. The array MUST contain at least one endpoint.
+    /// An array of tile endpoints.
+    ///
+    /// {z}, {x} and {y}, if present, are replaced with the corresponding integers.
+    /// If multiple endpoints are specified, clients may use any combination
+    /// of endpoints. All endpoint urls MUST be absolute. All endpoints MUST return
+    /// the same content for the same URL. The array MUST contain at least one endpoint.
+    /// The tile extension is NOT limited to any particular format.
+    /// Some of the more popular are: mvt, vector.pbf, png, webp, and jpg.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#32-tiles
     pub tiles: Vec<String>,
 
-    /// An array of interactivity endpoints. {z}, {x}
-    /// and {y}, if present, are replaced with the corresponding integers. If multiple
-    /// endpoints are specified, clients may use any combination of endpoints.
-    /// All endpoints MUST return the same content for the same URL.
-    /// If the array doesn't contain any entries, interactivity is not supported
-    /// for this tileset.
-    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2
-    /// for the interactivity specification.
+    /// An integer specifying the zoom level from which to generate overzoomed tiles.
+    ///
+    /// Implementations MAY generate overzoomed tiles from parent tiles if the requested
+    /// zoom level does not exist. In most cases, overzoomed tiles are generated from
+    /// the maximum zoom level of the set of tiles. If fillzoom is specified, the overzoomed
+    /// tile MAY be generated from the fillzoom level.
+    ///
+    /// For example, in a set of tiles with maxzoom 10 and no fillzoom specified,
+    /// a request for a z11 tile will use the z10 parent tiles to generate the new,
+    /// overzoomed z11 tile. If the same TileJSON object had fillzoom specified at z7,
+    /// a request for a z11 tile would use the z7 tile instead of z10.
+    ///
+    /// While TileJSON may specify rules for overzooming tiles, it is ultimately up to the tile
+    /// serving client or renderer to implement overzooming.
+    ///
+    /// OPTIONAL. Integer. Default: null.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#39-fillzoom
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fillzoom: Option<u8>,
+
+    /// An array of interactivity endpoints.
+    ///
+    /// {z}, {x} and {y}, if present, are replaced with the corresponding integers.
+    /// If multiple endpoints are specified, clients may use any combination of endpoints.
+    /// All endpoints MUST return the same content for the same URL. If the array doesn't
+    /// contain any entries, UTF-Grid interactivity is not supported for this set of tiles.
+    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2 for the interactivity specification.
+    ///
+    /// *Note: UTF-Grid interactivity predates GL-based map rendering and interaction.
+    /// Map interactivity is now generally defined outside of the TileJSON specification
+    /// and is dependent on the tile rendering library's features.*
+    ///
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#310-grids
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grids: Option<Vec<String>>,
 
     /// An array of data files in GeoJSON format.
-    /// {z}, {x} and {y}, if present,
-    /// are replaced with the corresponding integers. If multiple
-    /// endpoints are specified, clients may use any combination of endpoints.
-    /// All endpoints MUST return the same content for the same URL.
-    /// If the array doesn't contain any entries, then no data is present in
-    /// the map.
+    ///
+    /// {z}, {x} and {y}, if present, are replaced with the corresponding integers.
+    /// If multiple endpoints are specified, clients may use any combination of endpoints.
+    /// All endpoints MUST return the same content for the same URL. If the array doesn't
+    /// contain any entries, then no data is present in the map. This field is for overlaying
+    /// GeoJSON data on tiled raster maps and is generally no longer used for GL-based maps.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#37-data
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Vec<String>>,
 
     /// An integer specifying the minimum zoom level.
+    ///
+    /// MUST be in range: 0 <= minzoom <= maxzoom <= 30.
+    /// OPTIONAL. Integer. Default: 0.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#313-minzoom
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minzoom: Option<u8>,
 
-    /// An integer specifying the maximum zoom level. MUST be >= minzoom.
+    /// An integer specifying the maximum zoom level.
+    ///
+    /// MUST be in range: 0 <= minzoom <= maxzoom <= 30.
+    /// A client or server MAY request tiles outside of the zoom range,
+    /// but the availability of these tiles is dependent on how the the tile server
+    /// or renderer handles the request (such as overzooming tiles).
+    /// OPTIONAL. Integer. Default: 30.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#312-maxzoom
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maxzoom: Option<u8>,
 
-    /// The maximum extent of available map tiles. Bounds MUST define an area
-    /// covered by all zoom levels. The bounds are represented in WGS:84
-    /// latitude and longitude values, in the order left, bottom, right, top.
-    /// Values may be integers or floating point numbers.
+    /// The maximum extent of available map tiles.
+    ///
+    /// Bounds MUST define an area covered by all zoom levels. The bounds are represented
+    /// in WGS 84 latitude and longitude values, in the order left, bottom, right, top.
+    /// Values may be integers or floating point numbers. The minimum/maximum values for
+    /// longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap"
+    /// around the ante-meridian. If bounds are not present, the default value MAY assume
+    /// the set of tiles is globally distributed.
+    ///
+    /// Bounds where longitude values are the same, and latitude values are the same,
+    /// are considered valid. This case typically represents a single point geometry
+    /// in the entire tileset. For example: `[-122.34, 47.65, -122.34, 47.65]`.
+    ///
+    /// OPTIONAL. Array. Default: `[ -180, -85.05112877980659, 180, 85.0511287798066 ]` (xyz-compliant tile bounds)
+    ///
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Vec<f32>>,
 
-    /// The first value is the longitude, the second is latitude (both in
-    /// WGS:84 values), the third value is the zoom level as an integer.
-    /// Longitude and latitude MUST be within the specified bounds.
-    /// The zoom level MUST be between minzoom and maxzoom.
-    /// Implementations can use this value to set the default location. If the
-    /// value is null, implementations may use their own algorithm for
-    /// determining a default location.
+    /// The first value is the longitude, the second is latitude (both in WGS:84 values),
+    ///
+    /// the third value is the zoom level as an integer. Longitude and latitude MUST be
+    /// within the specified bounds. The zoom level MUST be between minzoom and maxzoom.
+    /// Implementations MAY use this center value to set the default location. If the value
+    /// is null, implementations MAY use their own algorithm for determining a default location.\
+    /// OPTIONAL. Array. Default: null.
+    /// Example: `"center": [ -76.275329586789, 39.153492567373, 8 ]`
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#36-center
     #[serde(skip_serializing_if = "Option::is_none")]
     pub center: Option<Vec<i32>>,
 }
@@ -125,6 +200,7 @@ pub struct TileJSONBuilder {
     legend: Option<String>,
     scheme: Option<String>,
     tiles: Vec<String>,
+    fillzoom: Option<u8>,
     grids: Option<Vec<String>>,
     data: Option<Vec<String>>,
     minzoom: Option<u8>,
@@ -133,13 +209,19 @@ pub struct TileJSONBuilder {
     center: Option<Vec<i32>>,
 }
 
+impl Default for TileJSONBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TileJSONBuilder {
     // Ignore the missing default because instantiation might need to be reworked.
     // See https://github.com/georust/tilejson/issues/10
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
-            tilejson: "2.2.0",
+            tilejson: "3.0.0",
             id: None,
             name: None,
             description: None,
@@ -149,6 +231,7 @@ impl TileJSONBuilder {
             legend: None,
             scheme: Some("xyz".to_string()),
             tiles: Vec::new(),
+            fillzoom: None,
             grids: None,
             data: None,
             minzoom: Some(0),
@@ -203,6 +286,11 @@ impl TileJSONBuilder {
         self
     }
 
+    pub fn fillzoom(&mut self, fillzoom: u8) -> &mut TileJSONBuilder {
+        self.fillzoom = Some(fillzoom);
+        self
+    }
+
     pub fn grids(&mut self, grids: Vec<&str>) -> &mut Self {
         self.grids = Some(grids.into_iter().map(|url| url.to_string()).collect());
         self
@@ -245,6 +333,7 @@ impl TileJSONBuilder {
             legend: self.legend,
             scheme: self.scheme,
             tiles: self.tiles,
+            fillzoom: self.fillzoom,
             grids: self.grids,
             data: self.data,
             minzoom: self.minzoom,
@@ -262,7 +351,7 @@ mod tests {
     #[test]
     fn test_reading() {
         let tilejson_str = r#"{
-        "tilejson": "2.2.0",
+        "tilejson": "3.0.0",
         "attribution": "",
         "name": "compositing",
         "scheme": "tms",
@@ -276,7 +365,7 @@ mod tests {
         assert_eq!(
             tilejson,
             TileJSON {
-                tilejson: "2.2.0".to_string(),
+                tilejson: "3.0.0".to_string(),
                 id: None,
                 name: Some("compositing".to_string()),
                 description: None,
@@ -289,6 +378,7 @@ mod tests {
                     "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"
                         .to_string()
                 ],
+                fillzoom: None,
                 grids: None,
                 data: None,
                 minzoom: None,
@@ -314,7 +404,7 @@ mod tests {
 
         assert_eq!(
             serialized_tilejson,
-            r#"{"tilejson":"2.2.0","name":"compositing","version":"1.0.0","scheme":"tms","tiles":["http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"],"minzoom":0,"maxzoom":30,"bounds":[-180.0,-90.0,180.0,90.0]}"#
+            r#"{"tilejson":"3.0.0","name":"compositing","version":"1.0.0","scheme":"tms","tiles":["http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"],"minzoom":0,"maxzoom":30,"bounds":[-180.0,-90.0,180.0,90.0]}"#
         )
     }
 }


### PR DESCRIPTION
* Update field documentation from [v3 of the spec](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
* Add `fillzoom` field

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
