### PR TITLE
Refactor instantiation, vector layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 ### Unreleased
 
-* for consistency, add `TileJSONBuilder::default()` - same as `::new()`
 * Migrate to Rust 2021 edition
-* Remove `serde_json` dependency
 * update docs to match v3.0.0 spec
 * add `fillzoom` field per v3.0.0 spec
 * add `Center` and `Bounds` structs instead of arrays
+* add `VectorLayer` struct and the `vector_layer` field
+* Remove builder pattern because `TileJSON` is writable 
+* Add `other` fields for any unknown fields in root and vector layers
+* Restructure instantiation:
+  * use `new(source)` or `new_ext(sources, version)` to create `TileJSON`
+  * use `set_missing_defaults()` to replace all missing values with their defaults (only if the spec defines it)
+* Remove `id` field because it is not supported by the spec
 
 <a name="v0.2.4"></a>
 ### v0.2.4 (2021-10-11)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ readme = "README.md"
 keywords = ["mapbox", "tilejson", "serde"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_tuple = "0.5"
-
-[dev-dependencies]
-serde_json = "1.0"

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+use std::collections::HashMap;
 
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Debug, Default)]
 pub struct Center {
@@ -57,6 +59,109 @@ impl From<Vec<f64>> for Bounds {
     }
 }
 
+/// Each object describes one layer of vector tile data.
+///
+/// A vector_layer object MUST contain the id and fields keys, and MAY contain the description,
+/// minzoom, or maxzoom keys. An implementation MAY include arbitrary keys in the object
+/// outside of those defined in this specification.
+///
+/// *Note: When describing a set of raster tiles or other tile format that does not have
+/// a "layers" concept (i.e. "format": "jpeg"), the vector_layers key is not required.*
+///
+/// These keys are used to describe the situation where different sets of vector layers
+/// appear in different zoom levels of the same set of tiles, for example in a case where
+/// a "minor roads" layer is only present at high zoom levels.
+///
+/// ```json
+/// {
+///   "vector_layers": [
+///     {
+///       "id": "roads",
+///       "description": "Roads and their attributes",
+///       "minzoom": 2,
+///       "maxzoom": 16,
+///       "fields": {
+///         "type": "One of: trunk, primary, secondary",
+///         "lanes": "Number",
+///         "name": "String",
+///         "sidewalks": "Boolean"
+///       }
+///     },
+///     {
+///       "id": "countries",
+///       "description": "Admin 0 (country) boundaries",
+///       "minzoom": 0,
+///       "maxzoom": 16,
+///       "fields": {
+///         "iso": "ISO 3166-1 Alpha-2 code",
+///         "name": "English name of the country",
+///         "name_ar": "Arabic name of the country"
+///       }
+///     },
+///     {
+///       "id": "buildings",
+///       "description": "A layer with an empty fields object",
+///       "fields": {}
+///     }
+///   ]
+/// }
+/// ```
+///
+/// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct VectorLayer {
+    /// A string value representing the the layer id.
+    ///
+    /// For added context, this is referred to as the name of the layer in the
+    /// [Mapbox Vector Tile spec](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers).
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#331-id
+    pub id: String,
+
+    /// An object whose keys and values are the names and descriptions of attributes available in this layer.
+    ///
+    /// Each value (description) MUST be a string that describes the underlying data.
+    /// If no fields are present, the fields key MUST be an empty object.
+    /// https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#332-fields
+    pub fields: HashMap<String, String>,
+
+    /// A string representing a human-readable description of the entire layer's contents.
+    ///
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#333-description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// An integer representing the highest zoom level whose tiles this layer appears in.
+    ///
+    /// maxzoom MUST be less than or equal to the set of tiles' maxzoom.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#334-minzoom-and-maxzoom
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maxzoom: Option<u8>,
+
+    /// An integer representing the lowest zoom level whose tiles this layer appears in.
+    ///
+    /// minzoom MUST be greater than or equal to the set of tiles' minzoom.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#334-minzoom-and-maxzoom
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minzoom: Option<u8>,
+
+    /// Any unrecognized fields will be stored here.
+    #[serde(flatten)]
+    pub other: HashMap<String, Value>,
+}
+
+impl VectorLayer {
+    pub fn new(id: String, fields: HashMap<String, String>) -> Self {
+        Self {
+            id,
+            fields,
+            description: None,
+            maxzoom: None,
+            minzoom: None,
+            other: Default::default(),
+        }
+    }
+}
+
 /// TileJSON struct represents tilejson-spec metadata as specified by
 /// https://github.com/mapbox/tilejson-spec (version 3.0.0)
 /// Some descriptions were copied verbatim from the spec per CC-BY 3.0 license.
@@ -68,74 +173,6 @@ pub struct TileJSON {
     /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#31-tilejson
     pub tilejson: String,
 
-    /// The tileset id.
-    ///
-    /// **This field is not part of the TileJSON spec and possibly may need to be deleted.**
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-
-    /// A name describing the tileset.
-    ///
-    /// The name can contain any legal character.
-    /// Implementations SHOULD NOT interpret the name as HTML.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#314-name
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-
-    /// A text description of the set of tiles.
-    ///
-    /// The description can contain any valid unicode character as described by the JSON specification RFC 8259.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#38-description
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// A semver.org style version number of the tiles.
-    ///
-    /// When changes across tiles are introduced the minor version MUST change.
-    /// This may lead to cut off labels. Therefore, implementors can decide to clean
-    /// their cache when the minor version changes. Changes to the patch level MUST
-    /// only have changes to tiles that are contained within one tile.
-    /// When tiles change significantly, such as updating a vector tile layer name,
-    /// the major version MUST be increased.
-    /// Implementations MUST NOT use tiles with different major versions.
-    /// OPTIONAL. String. Default: "1.0.0".
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#317-version
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-
-    /// Contains an attribution to be displayed when the map is shown to a user.
-    ///
-    /// Implementations MAY decide to treat this as HTML or literal text.
-    /// For security reasons, make absolutely sure that this content
-    /// can't be abused as a vector for XSS or beacon tracking.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#34-attribution
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub attribution: Option<String>,
-
-    /// Contains a mustache template to be used to format data from grids for interaction.
-    ///
-    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2 for the interactivity specification.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#316-template
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub template: Option<String>,
-
-    /// Contains a legend to be displayed with the map.
-    ///
-    /// Implementations MAY decide to treat this as HTML or literal text.
-    /// For security reasons, make absolutely sure that this field
-    /// can't be abused as a vector for XSS or beacon tracking.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#311-legend
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub legend: Option<String>,
-
-    /// Either "xyz" or "tms".
-    ///
-    /// Influences the y direction of the tile coordinates.
-    /// The global-mercator (aka Spherical Mercator) profile is assumed.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#315-scheme
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheme: Option<String>,
-
     /// An array of tile endpoints.
     ///
     /// {z}, {x} and {y}, if present, are replaced with the corresponding integers.
@@ -146,6 +183,77 @@ pub struct TileJSON {
     /// Some of the more popular are: mvt, vector.pbf, png, webp, and jpg.
     /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#32-tiles
     pub tiles: Vec<String>,
+
+    /// An array of objects. Each object describes one layer of vector tile data.
+    ///
+    /// A vector_layer object MUST contain the id and fields keys, and MAY contain the description,
+    /// minzoom, or maxzoom keys. An implementation MAY include arbitrary keys in the object
+    /// outside of those defined in this specification.
+    ///
+    /// *Note: When describing a set of raster tiles or other tile format that does not have
+    /// a "layers" concept (i.e. "format": "jpeg"), the vector_layers key is not required.*
+    ///
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_layers: Option<Vec<VectorLayer>>,
+
+    /// Contains an attribution to be displayed when the map is shown to a user.
+    ///
+    /// Implementations MAY decide to treat this as HTML or literal text.
+    /// For security reasons, make absolutely sure that this content
+    /// can't be abused as a vector for XSS or beacon tracking.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#34-attribution
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<String>,
+
+    /// The maximum extent of available map tiles.
+    ///
+    /// Bounds MUST define an area covered by all zoom levels. The bounds are represented
+    /// in WGS 84 latitude and longitude values, in the order left, bottom, right, top.
+    /// Values may be integers or floating point numbers. The minimum/maximum values for
+    /// longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap"
+    /// around the ante-meridian. If bounds are not present, the default value MAY assume
+    /// the set of tiles is globally distributed.
+    ///
+    /// Bounds where longitude values are the same, and latitude values are the same,
+    /// are considered valid. This case typically represents a single point geometry
+    /// in the entire tileset. For example: `[-122.34, 47.65, -122.34, 47.65]`.
+    ///
+    /// OPTIONAL. Array. Default: `[ -180, -85.05112877980659, 180, 85.0511287798066 ]` (xyz-compliant tile bounds)
+    ///
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounds: Option<Bounds>,
+
+    /// The first value is the longitude, the second is latitude (both in WGS:84 values),
+    ///
+    /// the third value is the zoom level as an integer. Longitude and latitude MUST be
+    /// within the specified bounds. The zoom level MUST be between minzoom and maxzoom.
+    /// Implementations MAY use this center value to set the default location. If the value
+    /// is null, implementations MAY use their own algorithm for determining a default location.\
+    /// OPTIONAL. Array. Default: null.
+    /// Example: `"center": [ -76.275329586789, 39.153492567373, 8 ]`
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#36-center
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub center: Option<Center>,
+
+    /// An array of data files in GeoJSON format.
+    ///
+    /// {z}, {x} and {y}, if present, are replaced with the corresponding integers.
+    /// If multiple endpoints are specified, clients may use any combination of endpoints.
+    /// All endpoints MUST return the same content for the same URL. If the array doesn't
+    /// contain any entries, then no data is present in the map. This field is for overlaying
+    /// GeoJSON data on tiled raster maps and is generally no longer used for GL-based maps.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#37-data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Vec<String>>,
+
+    /// A text description of the set of tiles.
+    ///
+    /// The description can contain any valid unicode character as described by the JSON specification RFC 8259.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#38-description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 
     /// An integer specifying the zoom level from which to generate overzoomed tiles.
     ///
@@ -183,24 +291,14 @@ pub struct TileJSON {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grids: Option<Vec<String>>,
 
-    /// An array of data files in GeoJSON format.
+    /// Contains a legend to be displayed with the map.
     ///
-    /// {z}, {x} and {y}, if present, are replaced with the corresponding integers.
-    /// If multiple endpoints are specified, clients may use any combination of endpoints.
-    /// All endpoints MUST return the same content for the same URL. If the array doesn't
-    /// contain any entries, then no data is present in the map. This field is for overlaying
-    /// GeoJSON data on tiled raster maps and is generally no longer used for GL-based maps.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#37-data
+    /// Implementations MAY decide to treat this as HTML or literal text.
+    /// For security reasons, make absolutely sure that this field
+    /// can't be abused as a vector for XSS or beacon tracking.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#311-legend
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Vec<String>>,
-
-    /// An integer specifying the minimum zoom level.
-    ///
-    /// MUST be in range: 0 <= minzoom <= maxzoom <= 30.
-    /// OPTIONAL. Integer. Default: 0.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#313-minzoom
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub minzoom: Option<u8>,
+    pub legend: Option<String>,
 
     /// An integer specifying the maximum zoom level.
     ///
@@ -213,191 +311,170 @@ pub struct TileJSON {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maxzoom: Option<u8>,
 
-    /// The maximum extent of available map tiles.
+    /// An integer specifying the minimum zoom level.
     ///
-    /// Bounds MUST define an area covered by all zoom levels. The bounds are represented
-    /// in WGS 84 latitude and longitude values, in the order left, bottom, right, top.
-    /// Values may be integers or floating point numbers. The minimum/maximum values for
-    /// longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap"
-    /// around the ante-meridian. If bounds are not present, the default value MAY assume
-    /// the set of tiles is globally distributed.
-    ///
-    /// Bounds where longitude values are the same, and latitude values are the same,
-    /// are considered valid. This case typically represents a single point geometry
-    /// in the entire tileset. For example: `[-122.34, 47.65, -122.34, 47.65]`.
-    ///
-    /// OPTIONAL. Array. Default: `[ -180, -85.05112877980659, 180, 85.0511287798066 ]` (xyz-compliant tile bounds)
-    ///
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds
+    /// MUST be in range: 0 <= minzoom <= maxzoom <= 30.
+    /// OPTIONAL. Integer. Default: 0.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#313-minzoom
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bounds: Option<Bounds>,
+    pub minzoom: Option<u8>,
 
-    /// The first value is the longitude, the second is latitude (both in WGS:84 values),
+    /// A name describing the tileset.
     ///
-    /// the third value is the zoom level as an integer. Longitude and latitude MUST be
-    /// within the specified bounds. The zoom level MUST be between minzoom and maxzoom.
-    /// Implementations MAY use this center value to set the default location. If the value
-    /// is null, implementations MAY use their own algorithm for determining a default location.\
-    /// OPTIONAL. Array. Default: null.
-    /// Example: `"center": [ -76.275329586789, 39.153492567373, 8 ]`
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#36-center
+    /// The name can contain any legal character.
+    /// Implementations SHOULD NOT interpret the name as HTML.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#314-name
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub center: Option<Center>,
+    pub name: Option<String>,
+
+    /// Either "xyz" or "tms".
+    ///
+    /// Influences the y direction of the tile coordinates.
+    /// The global-mercator (aka Spherical Mercator) profile is assumed.
+    /// OPTIONAL. String. Default: "xyz".
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#315-scheme
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
+
+    /// Contains a mustache template to be used to format data from grids for interaction.
+    ///
+    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2 for the interactivity specification.
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#316-template
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+
+    /// A semver.org style version number of the tiles.
+    ///
+    /// When changes across tiles are introduced the minor version MUST change.
+    /// This may lead to cut off labels. Therefore, implementors can decide to clean
+    /// their cache when the minor version changes. Changes to the patch level MUST
+    /// only have changes to tiles that are contained within one tile.
+    /// When tiles change significantly, such as updating a vector tile layer name,
+    /// the major version MUST be increased.
+    /// Implementations MUST NOT use tiles with different major versions.
+    /// OPTIONAL. String. Default: "1.0.0".
+    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#317-version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Any unrecognized fields will be stored here
+    #[serde(flatten)]
+    pub other: HashMap<String, Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct TileJSONBuilder {
-    tilejson: &'static str,
-    id: Option<String>,
-    name: Option<String>,
-    description: Option<String>,
-    version: Option<String>,
-    attribution: Option<String>,
-    template: Option<String>,
-    legend: Option<String>,
-    scheme: Option<String>,
-    tiles: Vec<String>,
-    fillzoom: Option<u8>,
-    grids: Option<Vec<String>>,
-    data: Option<Vec<String>>,
-    minzoom: Option<u8>,
-    maxzoom: Option<u8>,
-    bounds: Option<Bounds>,
-    center: Option<Center>,
-}
-
-impl Default for TileJSONBuilder {
-    fn default() -> Self {
-        Self::new()
+impl TileJSON {
+    /// create a builder with tilejson = 3.0.0 and tiles = `[ source ]`
+    pub fn new(source: String) -> Self {
+        Self::new_ext(vec![source], None)
     }
-}
 
-impl TileJSONBuilder {
-    // Ignore the missing default because instantiation might need to be reworked.
-    // See https://github.com/georust/tilejson/issues/10
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    /// create a builder with a custom version and multiple sources.
+    /// If version is None, use the current default.
+    pub fn new_ext(tiles_sources: Vec<String>, tilejson_version: Option<String>) -> Self {
         Self {
-            tilejson: "3.0.0",
-            id: None,
-            name: None,
-            description: None,
-            version: Some("1.0.0".to_string()),
+            tilejson: tilejson_version.unwrap_or_else(|| "3.0.0".to_string()),
+            tiles: tiles_sources,
+            vector_layers: None,
             attribution: None,
-            template: None,
-            legend: None,
-            scheme: Some("xyz".to_string()),
-            tiles: Vec::new(),
+            bounds: None,
+            center: None,
+            data: None,
+            description: None,
             fillzoom: None,
             grids: None,
-            data: None,
-            minzoom: Some(0),
-            maxzoom: Some(30),
-            bounds: Some(Bounds::new(-180.0, -90.0, 180.0, 90.0)),
-            center: None,
+            legend: None,
+            maxzoom: None,
+            minzoom: None,
+            name: None,
+            scheme: None,
+            template: None,
+            version: None,
+            other: Default::default(),
         }
     }
 
-    pub fn id(&mut self, id: &str) -> &mut Self {
-        self.id = Some(id.to_string());
+    /// Set any missing default values per tile-json specification
+    pub fn set_missing_defaults(&mut self) {
+        self.version.get_or_insert_with(|| "1.0.0".to_string());
+        self.scheme.get_or_insert_with(|| "xyz".to_string());
+        self.minzoom.get_or_insert(0);
+        self.maxzoom.get_or_insert(30);
+        self.bounds.get_or_insert_with(Bounds::default);
+    }
+
+    pub fn vector_layers(mut self, vector_layers: Vec<VectorLayer>) -> Self {
+        self.vector_layers = Some(vector_layers);
         self
     }
 
-    pub fn name(&mut self, name: &str) -> &mut Self {
-        self.name = Some(name.to_string());
+    pub fn attribution(mut self, attribution: String) -> Self {
+        self.attribution = Some(attribution);
         self
     }
 
-    pub fn description(&mut self, description: &str) -> &mut Self {
-        self.description = Some(description.to_string());
-        self
-    }
-
-    pub fn version(&mut self, version: &str) -> &mut Self {
-        self.version = Some(version.to_string());
-        self
-    }
-
-    pub fn attribution(&mut self, attribution: &str) -> &mut Self {
-        self.attribution = Some(attribution.to_string());
-        self
-    }
-
-    pub fn template(&mut self, template: &str) -> &mut Self {
-        self.template = Some(template.to_string());
-        self
-    }
-
-    pub fn legend(&mut self, legend: &str) -> &mut Self {
-        self.legend = Some(legend.to_string());
-        self
-    }
-
-    pub fn scheme(&mut self, scheme: &str) -> &mut Self {
-        self.scheme = Some(scheme.to_string());
-        self
-    }
-
-    pub fn tiles(&mut self, tiles: Vec<&str>) -> &mut Self {
-        self.tiles = tiles.into_iter().map(|url| url.to_string()).collect();
-        self
-    }
-
-    pub fn fillzoom(&mut self, fillzoom: u8) -> &mut TileJSONBuilder {
-        self.fillzoom = Some(fillzoom);
-        self
-    }
-
-    pub fn grids(&mut self, grids: Vec<&str>) -> &mut Self {
-        self.grids = Some(grids.into_iter().map(|url| url.to_string()).collect());
-        self
-    }
-
-    pub fn data(&mut self, data: Vec<&str>) -> &mut Self {
-        self.data = Some(data.into_iter().map(|url| url.to_string()).collect());
-        self
-    }
-
-    pub fn minzoom(&mut self, minzoom: u8) -> &mut Self {
-        self.minzoom = Some(minzoom);
-        self
-    }
-
-    pub fn maxzoom(&mut self, maxzoom: u8) -> &mut Self {
-        self.maxzoom = Some(maxzoom);
-        self
-    }
-
-    pub fn bounds(&mut self, bounds: Bounds) -> &mut Self {
+    pub fn bounds(mut self, bounds: Bounds) -> Self {
         self.bounds = Some(bounds);
         self
     }
 
-    pub fn center(&mut self, center: Center) -> &mut Self {
+    pub fn center(mut self, center: Center) -> Self {
         self.center = Some(center);
         self
     }
 
-    pub fn finalize(self) -> TileJSON {
-        TileJSON {
-            tilejson: self.tilejson.to_string(),
-            id: self.id,
-            name: self.name,
-            description: self.description,
-            version: self.version,
-            attribution: self.attribution,
-            template: self.template,
-            legend: self.legend,
-            scheme: self.scheme,
-            tiles: self.tiles,
-            fillzoom: self.fillzoom,
-            grids: self.grids,
-            data: self.data,
-            minzoom: self.minzoom,
-            maxzoom: self.maxzoom,
-            bounds: self.bounds,
-            center: self.center,
-        }
+    pub fn data(mut self, data: Vec<String>) -> Self {
+        self.data = Some(data);
+        self
+    }
+
+    pub fn description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn fillzoom(mut self, fillzoom: u8) -> Self {
+        self.fillzoom = Some(fillzoom);
+        self
+    }
+
+    pub fn grids(mut self, grids: Vec<String>) -> Self {
+        self.grids = Some(grids);
+        self
+    }
+
+    pub fn legend(mut self, legend: String) -> Self {
+        self.legend = Some(legend);
+        self
+    }
+
+    pub fn maxzoom(mut self, maxzoom: u8) -> Self {
+        self.maxzoom = Some(maxzoom);
+        self
+    }
+
+    pub fn minzoom(mut self, minzoom: u8) -> Self {
+        self.minzoom = Some(minzoom);
+        self
+    }
+
+    pub fn name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn scheme(mut self, scheme: String) -> Self {
+        self.scheme = Some(scheme);
+        self
+    }
+
+    pub fn template(mut self, template: String) -> Self {
+        self.template = Some(template);
+        self
+    }
+
+    pub fn version(mut self, version: String) -> Self {
+        self.version = Some(version);
+        self
     }
 }
 
@@ -413,59 +490,90 @@ mod tests {
         "name": "compositing",
         "scheme": "tms",
         "tiles": [
-            "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"
+            "http://localhost:8888/foo/{z}/{x}/{y}.png"
         ]
     }"#;
 
-        let tilejson: TileJSON = serde_json::from_str(&tilejson_str).unwrap();
+        let mut tilejson: TileJSON = serde_json::from_str(&tilejson_str).unwrap();
 
         assert_eq!(
             tilejson,
             TileJSON {
                 tilejson: "3.0.0".to_string(),
-                id: None,
-                name: Some("compositing".to_string()),
-                description: None,
-                version: None,
+                tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
+                vector_layers: None,
                 attribution: Some("".to_string()),
-                template: None,
-                legend: None,
-                scheme: Some("tms".to_string()),
-                tiles: vec![
-                    "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"
-                        .to_string()
-                ],
-                fillzoom: None,
-                grids: None,
-                data: None,
-                minzoom: None,
-                maxzoom: None,
                 bounds: None,
                 center: None,
+                data: None,
+                description: None,
+                fillzoom: None,
+                grids: None,
+                legend: None,
+                maxzoom: None,
+                minzoom: None,
+                name: Some("compositing".to_string()),
+                scheme: Some("tms".to_string()),
+                template: None,
+                version: None,
+                other: Default::default()
             }
-        )
+        );
+
+        tilejson.set_missing_defaults();
+
+        assert_eq!(
+            tilejson,
+            TileJSON {
+                tilejson: "3.0.0".to_string(),
+                tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
+                vector_layers: None,
+                attribution: Some("".to_string()),
+                bounds: Some(Bounds::new(
+                    -180.0,
+                    -85.05112877980659,
+                    180.0,
+                    85.0511287798066,
+                )),
+                center: None,
+                data: None,
+                description: None,
+                fillzoom: None,
+                grids: None,
+                legend: None,
+                maxzoom: Some(30),
+                minzoom: Some(0),
+                name: Some("compositing".to_string()),
+                scheme: Some("tms".to_string()),
+                template: None,
+                version: Some("1.0.0".to_string()),
+                other: Default::default()
+            }
+        );
     }
 
     #[test]
     fn test_writing() {
-        let mut tjb = TileJSONBuilder::new();
-
-        tjb.name("compositing");
-        tjb.scheme("tms");
-
-        let tiles = vec!["http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"];
-        tjb.tiles(tiles);
-
-        tjb.bounds(Bounds::new(-1.0, -2.0, 3.0, 4.0));
-        tjb.center(Center::new(-5.0, -6.0, 3));
-
-        let tilejson = tjb.finalize();
-        let serialized_tilejson = serde_json::to_string(&tilejson).unwrap();
+        let source = "http://localhost:8888/foo/{z}/{x}/{y}.png";
+        let tilejson = TileJSON::new(source.to_string())
+            .name("compositing".to_string())
+            .scheme("tms".to_string())
+            .bounds(Bounds::new(-1.0, -2.0, 3.0, 4.0))
+            .center(Center::new(-5.0, -6.0, 3));
 
         assert_eq!(
-            serialized_tilejson,
-            r#"{"tilejson":"3.0.0","name":"compositing","version":"1.0.0","scheme":"tms","tiles":["http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"],"minzoom":0,"maxzoom":30,"bounds":[-1.0,-2.0,3.0,4.0],"center":[-5.0,-6.0,3]}"#
-        )
+            serde_json::to_string(&tilejson).unwrap(),
+            r#"{"tilejson":"3.0.0","tiles":["http://localhost:8888/foo/{z}/{x}/{y}.png"],"bounds":[-1.0,-2.0,3.0,4.0],"center":[-5.0,-6.0,3],"name":"compositing","scheme":"tms"}"#,
+        );
+
+        let tilejson = TileJSON::new(source.to_string()).vector_layers(vec![VectorLayer::new(
+            "a".to_string(),
+            HashMap::from([("b".to_string(), "c".to_string())]),
+        )]);
+        assert_eq!(
+            serde_json::to_string(&tilejson).unwrap(),
+            r#"{"tilejson":"3.0.0","tiles":["http://localhost:8888/foo/{z}/{x}/{y}.png"],"vector_layers":[{"id":"a","fields":{"b":"c"}}]}"#,
+        );
     }
 
     fn parse(json_str: &str) -> serde_json::Result<TileJSON> {


### PR DESCRIPTION
fixes #10

* Order fields according to the spec
* Remove builder pattern because `TileJSON` is writable
* use `String` instead of `str` when setting struct values - per Rust general recommendations
* Add `other` fields for any unknown values in root and vector layers
* Restructure instantiation (see #10)
  * use `new(source)` or `new_ext(sources, version)` to create `TileJSON`
  * use `set_missing_defaults()` to replace all missing values with their defaults (only if the spec defines it)
* Remove `id` field because it is not supported by the spec

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

cc: @maxammann 