### PR TITLE
Use tilejson! macro for instantiation, refactor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Run cargo docs
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: -D warnings
+        with:
+          command: doc
+          args: --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Remove builder pattern because `TileJSON` is writable 
 * Add `other` fields for any unknown fields in root and vector layers
 * Restructure instantiation:
-  * use `new(source)` or `new_ext(sources, version)` to create `TileJSON`
+  * use `tilejson!{ source }` macro to create `TileJSON` objects, with any number of the optional `field: value` pairs. 
   * use `set_missing_defaults()` to replace all missing values with their defaults (only if the spec defines it)
 * Remove `id` field because it is not supported by the spec
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * update docs to match v3.0.0 spec
 * add `fillzoom` field per v3.0.0 spec
 * add `Center` and `Bounds` structs instead of arrays
+  * both support `FromStr` trait
 * add `VectorLayer` struct and the `vector_layer` field
 * Remove builder pattern because `TileJSON` is writable 
 * Add `other` fields for any unknown fields in root and vector layers

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -34,7 +34,7 @@ impl Default for Bounds {
 pub enum ParseBoundsError {
     /// Incorrect number of values
     BadLen,
-    // Wrapped error from the parse::<f64>()
+    /// Wrapped error from the parse::<f64>()
     ParseCoordError(ParseFloatError),
 }
 
@@ -72,6 +72,14 @@ impl FromStr for Bounds {
 
     /// Parse a string of four comma-separated values as a Bounds value,
     /// same order as the [Bounds::new] constructor. Extra spaces are ignored.
+    ///
+    /// # Example
+    /// ```
+    /// # use tilejson::Bounds;
+    /// # use std::str::FromStr;
+    /// let bounds = Bounds::from_str("-1.0, -2.0, 3, 4").unwrap();
+    /// assert_eq!(bounds, Bounds::new(-1.0, -2.0, 3.0, 4.0));
+    /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut vals = s.split(',').map(|s| s.trim());
         let mut next_val = || {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,0 +1,120 @@
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+use std::fmt::{Display, Formatter};
+use std::num::ParseFloatError;
+use std::str::FromStr;
+
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Debug, Copy, Clone)]
+pub struct Bounds {
+    pub left: f64,
+    pub bottom: f64,
+    pub right: f64,
+    pub top: f64,
+}
+
+impl Bounds {
+    pub fn new(left: f64, bottom: f64, right: f64, top: f64) -> Self {
+        Self {
+            left,
+            bottom,
+            right,
+            top,
+        }
+    }
+}
+
+impl Default for Bounds {
+    /// Default bounds are set to `[-180, -85.05112877980659, 180, 85.0511287798066]`
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds>
+    fn default() -> Self {
+        Self::new(-180.0, -85.05112877980659, 180.0, 85.0511287798066)
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ParseBoundsError {
+    /// Incorrect number of values
+    BadLen,
+    // Wrapped error from the parse::<f64>()
+    ParseCoordError(ParseFloatError),
+}
+
+impl Display for ParseBoundsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseBoundsError::BadLen => {
+                f.write_str("Incorrect number of values. Bounds expects four f64 values.")
+            }
+            ParseBoundsError::ParseCoordError(e) => e.fmt(f),
+        }
+    }
+}
+
+impl TryFrom<Vec<f64>> for Bounds {
+    type Error = ParseBoundsError;
+
+    /// Parse four f64 values as a Bounds value, same order as the [Bounds::new] constructor.
+    fn try_from(value: Vec<f64>) -> Result<Self, Self::Error> {
+        if value.len() == 4 {
+            Ok(Self {
+                left: value[0],
+                bottom: value[1],
+                right: value[2],
+                top: value[3],
+            })
+        } else {
+            Err(ParseBoundsError::BadLen)
+        }
+    }
+}
+
+impl FromStr for Bounds {
+    type Err = ParseBoundsError;
+
+    /// Parse a string of four comma-separated values as a Bounds value,
+    /// same order as the [Bounds::new] constructor. Extra spaces are ignored.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut vals = s.split(',').map(|s| s.trim());
+        let mut next_val = || {
+            vals.next().map_or(Err(ParseBoundsError::BadLen), |v| {
+                v.parse().map_err(ParseBoundsError::ParseCoordError)
+            })
+        };
+        let bounds = Self {
+            left: next_val()?,
+            bottom: next_val()?,
+            right: next_val()?,
+            top: next_val()?,
+        };
+        match vals.next() {
+            Some(_) => Err(ParseBoundsError::BadLen),
+            None => Ok(bounds),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_err() {
+        const E_EMPTY: &str = "cannot parse float from empty string";
+        const E_FORMAT: &str = "invalid float literal";
+        const E_LEN: &str = "Incorrect number of values. Bounds expects four f64 values.";
+
+        let err_to_str = |v| Bounds::from_str(v).unwrap_err().to_string();
+
+        assert_eq!(err_to_str(""), E_EMPTY);
+        assert_eq!(err_to_str("1"), E_LEN);
+        assert_eq!(err_to_str("1,2,3"), E_LEN);
+        assert_eq!(err_to_str("1,2,3,4,5"), E_LEN);
+        assert_eq!(err_to_str("1,2,3,a"), E_FORMAT);
+    }
+
+    #[test]
+    fn test_parse() {
+        let val = |s| Bounds::from_str(s).unwrap();
+        assert_eq!(val("0,0,0,0"), Bounds::new(0.0, 0.0, 0.0, 0.0));
+        assert_eq!(val(" 1 ,2.0, 3.0,  4.0 "), Bounds::new(1.0, 2.0, 3.0, 4.0));
+    }
+}

--- a/src/center.rs
+++ b/src/center.rs
@@ -1,0 +1,98 @@
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+use std::fmt::{Display, Formatter};
+use std::num::{ParseFloatError, ParseIntError};
+use std::str::FromStr;
+
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Debug, Default, Copy, Clone)]
+pub struct Center {
+    pub longitude: f64,
+    pub latitude: f64,
+    pub zoom: u8,
+}
+
+impl Center {
+    pub fn new(longitude: f64, latitude: f64, zoom: u8) -> Self {
+        Self {
+            longitude,
+            latitude,
+            zoom,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ParseCenterError {
+    /// Incorrect number of values
+    BadLen,
+    // Wrapped error from the parse::<f64>()
+    ParseCoordError(ParseFloatError),
+    // Wrapped error from the parse::<u8>()
+    ParseZoomError(ParseIntError),
+}
+
+impl Display for ParseCenterError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseCenterError::BadLen => {
+                f.write_str("Incorrect number of values. Center expects two f64 and one u8 values.")
+            }
+            ParseCenterError::ParseCoordError(e) => e.fmt(f),
+            ParseCenterError::ParseZoomError(e) => e.fmt(f),
+        }
+    }
+}
+
+impl FromStr for Center {
+    type Err = ParseCenterError;
+
+    /// Parse a string of four comma-separated values as a Center value,
+    /// same order as the [Center::new] constructor. Extra spaces are ignored.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut vals = s.split(',').map(|s| s.trim());
+        let mut next_val = || vals.next().ok_or(ParseCenterError::BadLen);
+        let center = Self {
+            longitude: next_val()?
+                .parse()
+                .map_err(ParseCenterError::ParseCoordError)?,
+            latitude: next_val()?
+                .parse()
+                .map_err(ParseCenterError::ParseCoordError)?,
+            zoom: next_val()?
+                .parse()
+                .map_err(ParseCenterError::ParseZoomError)?,
+        };
+        match vals.next() {
+            Some(_) => Err(ParseCenterError::BadLen),
+            None => Ok(center),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_err() {
+        const E_EMPTY: &str = "cannot parse float from empty string";
+        const E_FORMAT: &str = "invalid digit found in string";
+        const E_LEN: &str = "Incorrect number of values. Center expects two f64 and one u8 values.";
+
+        let err_to_str = |s| Center::from_str(s).unwrap_err().to_string();
+
+        assert_eq!(err_to_str(""), E_EMPTY);
+        assert_eq!(err_to_str("1"), E_LEN);
+        assert_eq!(err_to_str("1,2"), E_LEN);
+        assert_eq!(err_to_str("1,2,3,4"), E_LEN);
+        assert_eq!(err_to_str("1,2,a"), E_FORMAT);
+        assert_eq!(err_to_str("1,2,1.1"), E_FORMAT);
+        assert_eq!(err_to_str("1,,0"), E_EMPTY);
+    }
+
+    #[test]
+    fn test_parse() {
+        let val = |s| Center::from_str(s).unwrap();
+        assert_eq!(val("0,0,0"), Center::new(0.0, 0.0, 0));
+        assert_eq!(val("  1 ,2.0, 3 "), Center::new(1.0, 2.0, 3));
+    }
+}

--- a/src/center.rs
+++ b/src/center.rs
@@ -24,9 +24,9 @@ impl Center {
 pub enum ParseCenterError {
     /// Incorrect number of values
     BadLen,
-    // Wrapped error from the parse::<f64>()
+    /// Wrapped error from the parse::<f64>()
     ParseCoordError(ParseFloatError),
-    // Wrapped error from the parse::<u8>()
+    /// Wrapped error from the parse::<u8>()
     ParseZoomError(ParseIntError),
 }
 
@@ -47,6 +47,13 @@ impl FromStr for Center {
 
     /// Parse a string of four comma-separated values as a Center value,
     /// same order as the [Center::new] constructor. Extra spaces are ignored.
+    ///
+    /// # Example
+    /// ```
+    /// # use tilejson::Center;
+    /// # use std::str::FromStr;
+    /// let center = Center::from_str("1.0, 2.0, 3").unwrap();
+    /// assert_eq!(center, Center::new(1.0, 2.0, 3));
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut vals = s.split(',').map(|s| s.trim());
         let mut next_val = || vals.next().ok_or(ParseCenterError::BadLen);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,18 @@
 //! # TileJSON
 //!
-//! `tilejson` is a crate for serializing/deserializing TileJSON format —
+//! `tilejson` is a crate for serializing/deserializing
+//! [TileJSON format](https://github.com/mapbox/tilejson-spec) —
 //! an open standard for representing map metadata.
+//!
+//! Use [tilejson!] macro to instantiate a valid [TileJSON].
+//! Use [TileJSON::set_missing_defaults] to populate default values per spec.
 
-pub mod tilejson;
+mod bounds;
+mod center;
+mod tilejson;
+mod vector_layer;
+
+pub use crate::bounds::*;
+pub use crate::center::*;
 pub use crate::tilejson::*;
+pub use crate::vector_layer::*;

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -243,25 +243,25 @@ impl TileJSON {
 /// assert_eq!(tj.tiles[0], "https://example.com/");
 ///
 /// // With the optional tilejson version (must be used in this order)
-/// let tj = tilejson! { "https://example.com/".to_string(), tilejson: "2.1.0".to_string() };
+/// let tj = tilejson! { tilejson: "2.1.0".to_string(), tiles: vec!["https://example.com/".to_string()], };
 /// assert_eq!(tj.tiles[0], "https://example.com/");
 /// assert_eq!(tj.tilejson, "2.1.0");
 ///
 /// // Other optional values could be used at the end
-/// let tj = tilejson! { "https://example.com/".to_string(), minzoom: 5 };
+/// let tj = tilejson! { tiles: vec!["https://example.com/".to_string()], minzoom: 5 };
 /// assert_eq!(tj.tiles[0], "https://example.com/");
 /// assert_eq!(tj.tilejson, "3.0.0");
 /// assert_eq!(tj.minzoom, Some(5));
 ///
 /// // version and optional values together
-/// let tj = tilejson! { "https://example.com/".to_string(), tilejson: "2.2.0".to_string(), minzoom: 5 };
+/// let tj = tilejson! { tilejson: "2.2.0".to_string(), tiles: vec!["https://example.com/".to_string()], minzoom: 5 };
 /// assert_eq!(tj.tiles[0], "https://example.com/");
 /// assert_eq!(tj.tilejson, "2.2.0");
 /// assert_eq!(tj.minzoom, Some(5));
 /// ```
 #[macro_export]
 macro_rules! tilejson {
-    ( tiles: $sources:expr, tilejson: $ver:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
+    ( tilejson: $ver:expr, tiles: $sources:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
         $crate::TileJSON {
             $( $tag: Some($val), )*
             ..$crate::TileJSON {
@@ -288,8 +288,8 @@ macro_rules! tilejson {
     };
     ( tiles: $sources:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
         $crate::tilejson! {
-            tiles: $sources,
             tilejson: "3.0.0".to_string(),
+            tiles: $sources,
             $( $tag: $val , )* }
     };
     ( $tile_source:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
@@ -320,8 +320,8 @@ mod tests {
         assert_eq!(
             tilejson,
             tilejson! {
-                tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
                 tilejson: "3.0.0".to_string(),
+                tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
                 attribution: "".to_string(),
                 name: "compositing".to_string(),
                 scheme: "tms".to_string(),
@@ -333,8 +333,8 @@ mod tests {
         assert_eq!(
             tilejson,
             tilejson! {
-                tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
                 tilejson: "3.0.0".to_string(),
+                tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
                 attribution: "".to_string(),
                 name: "compositing".to_string(),
                 scheme: "tms".to_string(),

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -1,176 +1,19 @@
+use crate::bounds::Bounds;
+use crate::center::Center;
+use crate::vector_layer::VectorLayer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::collections::HashMap;
 
-#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Debug, Default)]
-pub struct Center {
-    pub longitude: f64,
-    pub latitude: f64,
-    pub zoom: u8,
-}
-
-impl Center {
-    pub fn new(longitude: f64, latitude: f64, zoom: u8) -> Self {
-        Self {
-            longitude,
-            latitude,
-            zoom,
-        }
-    }
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Debug)]
-pub struct Bounds {
-    pub left: f64,
-    pub bottom: f64,
-    pub right: f64,
-    pub top: f64,
-}
-
-impl Bounds {
-    pub fn new(left: f64, bottom: f64, right: f64, top: f64) -> Self {
-        Self {
-            left,
-            bottom,
-            right,
-            top,
-        }
-    }
-}
-
-impl Default for Bounds {
-    /// Default bounds are set to `[-180, -85.05112877980659, 180, 85.0511287798066]`
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds
-    fn default() -> Self {
-        Self::new(-180.0, -85.05112877980659, 180.0, 85.0511287798066)
-    }
-}
-
-impl From<Vec<f64>> for Bounds {
-    fn from(item: Vec<f64>) -> Self {
-        assert_eq!(item.len(), 4, "bounds must be an array with 4 values");
-        Self {
-            left: item[0],
-            bottom: item[1],
-            right: item[2],
-            top: item[3],
-        }
-    }
-}
-
-/// Each object describes one layer of vector tile data.
-///
-/// A vector_layer object MUST contain the id and fields keys, and MAY contain the description,
-/// minzoom, or maxzoom keys. An implementation MAY include arbitrary keys in the object
-/// outside of those defined in this specification.
-///
-/// *Note: When describing a set of raster tiles or other tile format that does not have
-/// a "layers" concept (i.e. "format": "jpeg"), the vector_layers key is not required.*
-///
-/// These keys are used to describe the situation where different sets of vector layers
-/// appear in different zoom levels of the same set of tiles, for example in a case where
-/// a "minor roads" layer is only present at high zoom levels.
-///
-/// ```json
-/// {
-///   "vector_layers": [
-///     {
-///       "id": "roads",
-///       "description": "Roads and their attributes",
-///       "minzoom": 2,
-///       "maxzoom": 16,
-///       "fields": {
-///         "type": "One of: trunk, primary, secondary",
-///         "lanes": "Number",
-///         "name": "String",
-///         "sidewalks": "Boolean"
-///       }
-///     },
-///     {
-///       "id": "countries",
-///       "description": "Admin 0 (country) boundaries",
-///       "minzoom": 0,
-///       "maxzoom": 16,
-///       "fields": {
-///         "iso": "ISO 3166-1 Alpha-2 code",
-///         "name": "English name of the country",
-///         "name_ar": "Arabic name of the country"
-///       }
-///     },
-///     {
-///       "id": "buildings",
-///       "description": "A layer with an empty fields object",
-///       "fields": {}
-///     }
-///   ]
-/// }
-/// ```
-///
-/// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub struct VectorLayer {
-    /// A string value representing the the layer id.
-    ///
-    /// For added context, this is referred to as the name of the layer in the
-    /// [Mapbox Vector Tile spec](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers).
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#331-id
-    pub id: String,
-
-    /// An object whose keys and values are the names and descriptions of attributes available in this layer.
-    ///
-    /// Each value (description) MUST be a string that describes the underlying data.
-    /// If no fields are present, the fields key MUST be an empty object.
-    /// https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#332-fields
-    pub fields: HashMap<String, String>,
-
-    /// A string representing a human-readable description of the entire layer's contents.
-    ///
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#333-description
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// An integer representing the highest zoom level whose tiles this layer appears in.
-    ///
-    /// maxzoom MUST be less than or equal to the set of tiles' maxzoom.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#334-minzoom-and-maxzoom
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub maxzoom: Option<u8>,
-
-    /// An integer representing the lowest zoom level whose tiles this layer appears in.
-    ///
-    /// minzoom MUST be greater than or equal to the set of tiles' minzoom.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#334-minzoom-and-maxzoom
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub minzoom: Option<u8>,
-
-    /// Any unrecognized fields will be stored here.
-    #[serde(flatten)]
-    pub other: HashMap<String, Value>,
-}
-
-impl VectorLayer {
-    pub fn new(id: String, fields: HashMap<String, String>) -> Self {
-        Self {
-            id,
-            fields,
-            description: None,
-            maxzoom: None,
-            minzoom: None,
-            other: Default::default(),
-        }
-    }
-}
-
 /// TileJSON struct represents tilejson-spec metadata as specified by
-/// https://github.com/mapbox/tilejson-spec (version 3.0.0)
+/// <https://github.com/mapbox/tilejson-spec> (version 3.0.0)
 /// Some descriptions were copied verbatim from the spec per CC-BY 3.0 license.
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct TileJSON {
     /// A semver.org style version number as a string.
     /// Describes the version of the TileJSON spec that is implemented by this JSON object.
     /// Example: `"3.0.0"`
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#31-tilejson
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#31-tilejson>
     pub tilejson: String,
 
     /// An array of tile endpoints.
@@ -181,7 +24,7 @@ pub struct TileJSON {
     /// the same content for the same URL. The array MUST contain at least one endpoint.
     /// The tile extension is NOT limited to any particular format.
     /// Some of the more popular are: mvt, vector.pbf, png, webp, and jpg.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#32-tiles
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#32-tiles>
     pub tiles: Vec<String>,
 
     /// An array of objects. Each object describes one layer of vector tile data.
@@ -193,7 +36,7 @@ pub struct TileJSON {
     /// *Note: When describing a set of raster tiles or other tile format that does not have
     /// a "layers" concept (i.e. "format": "jpeg"), the vector_layers key is not required.*
     ///
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vector_layers: Option<Vec<VectorLayer>>,
 
@@ -202,7 +45,7 @@ pub struct TileJSON {
     /// Implementations MAY decide to treat this as HTML or literal text.
     /// For security reasons, make absolutely sure that this content
     /// can't be abused as a vector for XSS or beacon tracking.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#34-attribution
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#34-attribution>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attribution: Option<String>,
 
@@ -221,7 +64,7 @@ pub struct TileJSON {
     ///
     /// OPTIONAL. Array. Default: `[ -180, -85.05112877980659, 180, 85.0511287798066 ]` (xyz-compliant tile bounds)
     ///
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#35-bounds>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Bounds>,
 
@@ -233,7 +76,7 @@ pub struct TileJSON {
     /// is null, implementations MAY use their own algorithm for determining a default location.\
     /// OPTIONAL. Array. Default: null.
     /// Example: `"center": [ -76.275329586789, 39.153492567373, 8 ]`
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#36-center
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#36-center>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub center: Option<Center>,
 
@@ -244,14 +87,14 @@ pub struct TileJSON {
     /// All endpoints MUST return the same content for the same URL. If the array doesn't
     /// contain any entries, then no data is present in the map. This field is for overlaying
     /// GeoJSON data on tiled raster maps and is generally no longer used for GL-based maps.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#37-data
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#37-data>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Vec<String>>,
 
     /// A text description of the set of tiles.
     ///
     /// The description can contain any valid unicode character as described by the JSON specification RFC 8259.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#38-description
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#38-description>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
@@ -271,7 +114,7 @@ pub struct TileJSON {
     /// serving client or renderer to implement overzooming.
     ///
     /// OPTIONAL. Integer. Default: null.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#39-fillzoom
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#39-fillzoom>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fillzoom: Option<u8>,
 
@@ -281,13 +124,13 @@ pub struct TileJSON {
     /// If multiple endpoints are specified, clients may use any combination of endpoints.
     /// All endpoints MUST return the same content for the same URL. If the array doesn't
     /// contain any entries, UTF-Grid interactivity is not supported for this set of tiles.
-    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2 for the interactivity specification.
+    /// See <https://github.com/mapbox/utfgrid-spec/tree/master/1.2> for the interactivity specification.
     ///
     /// *Note: UTF-Grid interactivity predates GL-based map rendering and interaction.
     /// Map interactivity is now generally defined outside of the TileJSON specification
     /// and is dependent on the tile rendering library's features.*
     ///
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#310-grids
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#310-grids>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grids: Option<Vec<String>>,
 
@@ -296,7 +139,7 @@ pub struct TileJSON {
     /// Implementations MAY decide to treat this as HTML or literal text.
     /// For security reasons, make absolutely sure that this field
     /// can't be abused as a vector for XSS or beacon tracking.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#311-legend
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#311-legend>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub legend: Option<String>,
 
@@ -307,7 +150,7 @@ pub struct TileJSON {
     /// but the availability of these tiles is dependent on how the the tile server
     /// or renderer handles the request (such as overzooming tiles).
     /// OPTIONAL. Integer. Default: 30.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#312-maxzoom
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#312-maxzoom>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maxzoom: Option<u8>,
 
@@ -315,7 +158,7 @@ pub struct TileJSON {
     ///
     /// MUST be in range: 0 <= minzoom <= maxzoom <= 30.
     /// OPTIONAL. Integer. Default: 0.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#313-minzoom
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#313-minzoom>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minzoom: Option<u8>,
 
@@ -323,7 +166,7 @@ pub struct TileJSON {
     ///
     /// The name can contain any legal character.
     /// Implementations SHOULD NOT interpret the name as HTML.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#314-name
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#314-name>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
@@ -332,14 +175,14 @@ pub struct TileJSON {
     /// Influences the y direction of the tile coordinates.
     /// The global-mercator (aka Spherical Mercator) profile is assumed.
     /// OPTIONAL. String. Default: "xyz".
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#315-scheme
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#315-scheme>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scheme: Option<String>,
 
     /// Contains a mustache template to be used to format data from grids for interaction.
     ///
-    /// See https://github.com/mapbox/utfgrid-spec/tree/master/1.2 for the interactivity specification.
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#316-template
+    /// See <https://github.com/mapbox/utfgrid-spec/tree/master/1.2> for the interactivity specification.
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#316-template>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<String>,
 
@@ -353,7 +196,7 @@ pub struct TileJSON {
     /// the major version MUST be increased.
     /// Implementations MUST NOT use tiles with different major versions.
     /// OPTIONAL. String. Default: "1.0.0".
-    /// See https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#317-version
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#317-version>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
@@ -363,36 +206,6 @@ pub struct TileJSON {
 }
 
 impl TileJSON {
-    /// create a builder with tilejson = 3.0.0 and tiles = `[ source ]`
-    pub fn new(source: String) -> Self {
-        Self::new_ext(vec![source], None)
-    }
-
-    /// create a builder with a custom version and multiple sources.
-    /// If version is None, use the current default.
-    pub fn new_ext(tiles_sources: Vec<String>, tilejson_version: Option<String>) -> Self {
-        Self {
-            tilejson: tilejson_version.unwrap_or_else(|| "3.0.0".to_string()),
-            tiles: tiles_sources,
-            vector_layers: None,
-            attribution: None,
-            bounds: None,
-            center: None,
-            data: None,
-            description: None,
-            fillzoom: None,
-            grids: None,
-            legend: None,
-            maxzoom: None,
-            minzoom: None,
-            name: None,
-            scheme: None,
-            template: None,
-            version: None,
-            other: Default::default(),
-        }
-    }
-
     /// Set any missing default values per tile-json specification
     pub fn set_missing_defaults(&mut self) {
         self.version.get_or_insert_with(|| "1.0.0".to_string());
@@ -401,81 +214,89 @@ impl TileJSON {
         self.maxzoom.get_or_insert(30);
         self.bounds.get_or_insert_with(Bounds::default);
     }
+}
 
-    pub fn vector_layers(mut self, vector_layers: Vec<VectorLayer>) -> Self {
-        self.vector_layers = Some(vector_layers);
-        self
-    }
-
-    pub fn attribution(mut self, attribution: String) -> Self {
-        self.attribution = Some(attribution);
-        self
-    }
-
-    pub fn bounds(mut self, bounds: Bounds) -> Self {
-        self.bounds = Some(bounds);
-        self
-    }
-
-    pub fn center(mut self, center: Center) -> Self {
-        self.center = Some(center);
-        self
-    }
-
-    pub fn data(mut self, data: Vec<String>) -> Self {
-        self.data = Some(data);
-        self
-    }
-
-    pub fn description(mut self, description: String) -> Self {
-        self.description = Some(description);
-        self
-    }
-
-    pub fn fillzoom(mut self, fillzoom: u8) -> Self {
-        self.fillzoom = Some(fillzoom);
-        self
-    }
-
-    pub fn grids(mut self, grids: Vec<String>) -> Self {
-        self.grids = Some(grids);
-        self
-    }
-
-    pub fn legend(mut self, legend: String) -> Self {
-        self.legend = Some(legend);
-        self
-    }
-
-    pub fn maxzoom(mut self, maxzoom: u8) -> Self {
-        self.maxzoom = Some(maxzoom);
-        self
-    }
-
-    pub fn minzoom(mut self, minzoom: u8) -> Self {
-        self.minzoom = Some(minzoom);
-        self
-    }
-
-    pub fn name(mut self, name: String) -> Self {
-        self.name = Some(name);
-        self
-    }
-
-    pub fn scheme(mut self, scheme: String) -> Self {
-        self.scheme = Some(scheme);
-        self
-    }
-
-    pub fn template(mut self, template: String) -> Self {
-        self.template = Some(template);
-        self
-    }
-
-    pub fn version(mut self, version: String) -> Self {
-        self.version = Some(version);
-        self
-    }
+/// Use this macro to create a TileJSON struct with optional values.
+/// The `tilejson!` macro can be used in several ways:
+///
+/// ### With a single tile source
+/// ```
+/// # use crate::tilejson::tilejson;
+/// // The tile source is auto-converted to a vector
+/// let tj = tilejson! { "https://example.com/".to_string() };
+/// assert_eq!(tj.tiles[0], "https://example.com/");
+/// assert_eq!(tj.tilejson, "3.0.0");
+/// assert_eq!(tj.minzoom, None);
+///
+/// // With optional values
+/// let tj = tilejson! { "https://example.com/".to_string(), minzoom: 1, maxzoom: 2 };
+/// assert_eq!(tj.tiles[0], "https://example.com/");
+/// assert_eq!(tj.minzoom, Some(1));
+/// assert_eq!(tj.maxzoom, Some(2));
+/// ```
+///
+/// ### With multiple tile sources and an optional version
+/// ```
+/// # use crate::tilejson::tilejson;
+/// // Could use any number of tile sources here
+/// let tj = tilejson! { tiles: vec!["https://example.com/".to_string()] };
+/// assert_eq!(tj.tiles[0], "https://example.com/");
+///
+/// // With the optional tilejson version (must be used in this order)
+/// let tj = tilejson! { "https://example.com/".to_string(), tilejson: "2.1.0".to_string() };
+/// assert_eq!(tj.tiles[0], "https://example.com/");
+/// assert_eq!(tj.tilejson, "2.1.0");
+///
+/// // Other optional values could be used at the end
+/// let tj = tilejson! { "https://example.com/".to_string(), minzoom: 5 };
+/// assert_eq!(tj.tiles[0], "https://example.com/");
+/// assert_eq!(tj.tilejson, "3.0.0");
+/// assert_eq!(tj.minzoom, Some(5));
+///
+/// // version and optional values together
+/// let tj = tilejson! { "https://example.com/".to_string(), tilejson: "2.2.0".to_string(), minzoom: 5 };
+/// assert_eq!(tj.tiles[0], "https://example.com/");
+/// assert_eq!(tj.tilejson, "2.2.0");
+/// assert_eq!(tj.minzoom, Some(5));
+/// ```
+#[macro_export]
+macro_rules! tilejson {
+    ( tiles: $sources:expr, tilejson: $ver:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
+        $crate::TileJSON {
+            $( $tag: Some($val), )*
+            ..$crate::TileJSON {
+                tilejson: $ver,
+                tiles: $sources,
+                vector_layers: None,
+                attribution: None,
+                bounds: None,
+                center: None,
+                data: None,
+                description: None,
+                fillzoom: None,
+                grids: None,
+                legend: None,
+                maxzoom: None,
+                minzoom: None,
+                name: None,
+                scheme: None,
+                template: None,
+                version: None,
+                other: Default::default(),
+            }
+        }
+    };
+    ( tiles: $sources:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
+        $crate::tilejson! {
+            tiles: $sources,
+            tilejson: "3.0.0".to_string(),
+            $( $tag: $val , )* }
+    };
+    ( $tile_source:expr $(, $tag:tt : $val:expr)* $(,)? ) => {
+        $crate::tilejson! {
+            tiles: vec! [ $tile_source ],
+            $( $tag: $val , )* }
+    };
 }
 
 #[cfg(test)]
@@ -498,25 +319,12 @@ mod tests {
 
         assert_eq!(
             tilejson,
-            TileJSON {
-                tilejson: "3.0.0".to_string(),
+            tilejson! {
                 tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
-                vector_layers: None,
-                attribution: Some("".to_string()),
-                bounds: None,
-                center: None,
-                data: None,
-                description: None,
-                fillzoom: None,
-                grids: None,
-                legend: None,
-                maxzoom: None,
-                minzoom: None,
-                name: Some("compositing".to_string()),
-                scheme: Some("tms".to_string()),
-                template: None,
-                version: None,
-                other: Default::default()
+                tilejson: "3.0.0".to_string(),
+                attribution: "".to_string(),
+                name: "compositing".to_string(),
+                scheme: "tms".to_string(),
             }
         );
 
@@ -524,30 +332,21 @@ mod tests {
 
         assert_eq!(
             tilejson,
-            TileJSON {
-                tilejson: "3.0.0".to_string(),
+            tilejson! {
                 tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
-                vector_layers: None,
-                attribution: Some("".to_string()),
-                bounds: Some(Bounds::new(
+                tilejson: "3.0.0".to_string(),
+                attribution: "".to_string(),
+                name: "compositing".to_string(),
+                scheme: "tms".to_string(),
+                bounds: Bounds::new(
                     -180.0,
                     -85.05112877980659,
                     180.0,
                     85.0511287798066,
-                )),
-                center: None,
-                data: None,
-                description: None,
-                fillzoom: None,
-                grids: None,
-                legend: None,
-                maxzoom: Some(30),
-                minzoom: Some(0),
-                name: Some("compositing".to_string()),
-                scheme: Some("tms".to_string()),
-                template: None,
-                version: Some("1.0.0".to_string()),
-                other: Default::default()
+                ),
+                maxzoom: 30,
+                minzoom: 0,
+                version: "1.0.0".to_string(),
             }
         );
     }
@@ -555,23 +354,30 @@ mod tests {
     #[test]
     fn test_writing() {
         let source = "http://localhost:8888/foo/{z}/{x}/{y}.png";
-        let tilejson = TileJSON::new(source.to_string())
-            .name("compositing".to_string())
-            .scheme("tms".to_string())
-            .bounds(Bounds::new(-1.0, -2.0, 3.0, 4.0))
-            .center(Center::new(-5.0, -6.0, 3));
+        let tj = tilejson! {
+            source.to_string(),
+            name: "compositing".to_string(),
+            scheme: "tms".to_string(),
+            bounds: Bounds::new(-1.0, -2.0, 3.0, 4.0),
+            center: Center::new(-5.0, -6.0, 3),
+        };
 
         assert_eq!(
-            serde_json::to_string(&tilejson).unwrap(),
+            serde_json::to_string(&tj).unwrap(),
             r#"{"tilejson":"3.0.0","tiles":["http://localhost:8888/foo/{z}/{x}/{y}.png"],"bounds":[-1.0,-2.0,3.0,4.0],"center":[-5.0,-6.0,3],"name":"compositing","scheme":"tms"}"#,
         );
 
-        let tilejson = TileJSON::new(source.to_string()).vector_layers(vec![VectorLayer::new(
+        let vl = VectorLayer::new(
             "a".to_string(),
             HashMap::from([("b".to_string(), "c".to_string())]),
-        )]);
+        );
+        let tj = tilejson! {
+            source.to_string(),
+            vector_layers: vec![vl]
+        };
+
         assert_eq!(
-            serde_json::to_string(&tilejson).unwrap(),
+            serde_json::to_string(&tj).unwrap(),
             r#"{"tilejson":"3.0.0","tiles":["http://localhost:8888/foo/{z}/{x}/{y}.png"],"vector_layers":[{"id":"a","fields":{"b":"c"}}]}"#,
         );
     }

--- a/src/vector_layer.rs
+++ b/src/vector_layer.rs
@@ -1,0 +1,106 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Each object describes one layer of vector tile data.
+///
+/// A vector_layer object MUST contain the id and fields keys, and MAY contain the description,
+/// minzoom, or maxzoom keys. An implementation MAY include arbitrary keys in the object
+/// outside of those defined in this specification.
+///
+/// *Note: When describing a set of raster tiles or other tile format that does not have
+/// a "layers" concept (i.e. "format": "jpeg"), the vector_layers key is not required.*
+///
+/// These keys are used to describe the situation where different sets of vector layers
+/// appear in different zoom levels of the same set of tiles, for example in a case where
+/// a "minor roads" layer is only present at high zoom levels.
+///
+/// ```json
+/// {
+///   "vector_layers": [
+///     {
+///       "id": "roads",
+///       "description": "Roads and their attributes",
+///       "minzoom": 2,
+///       "maxzoom": 16,
+///       "fields": {
+///         "type": "One of: trunk, primary, secondary",
+///         "lanes": "Number",
+///         "name": "String",
+///         "sidewalks": "Boolean"
+///       }
+///     },
+///     {
+///       "id": "countries",
+///       "description": "Admin 0 (country) boundaries",
+///       "minzoom": 0,
+///       "maxzoom": 16,
+///       "fields": {
+///         "iso": "ISO 3166-1 Alpha-2 code",
+///         "name": "English name of the country",
+///         "name_ar": "Arabic name of the country"
+///       }
+///     },
+///     {
+///       "id": "buildings",
+///       "description": "A layer with an empty fields object",
+///       "fields": {}
+///     }
+///   ]
+/// }
+/// ```
+///
+/// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#33-vector_layers>
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct VectorLayer {
+    /// A string value representing the the layer id.
+    ///
+    /// For added context, this is referred to as the name of the layer in the
+    /// [Mapbox Vector Tile spec](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers).
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#331-id>
+    pub id: String,
+
+    /// An object whose keys and values are the names and descriptions of attributes available in this layer.
+    ///
+    /// Each value (description) MUST be a string that describes the underlying data.
+    /// If no fields are present, the fields key MUST be an empty object.
+    /// <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#332-fields>
+    pub fields: HashMap<String, String>,
+
+    /// A string representing a human-readable description of the entire layer's contents.
+    ///
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#333-description>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// An integer representing the highest zoom level whose tiles this layer appears in.
+    ///
+    /// maxzoom MUST be less than or equal to the set of tiles' maxzoom.
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#334-minzoom-and-maxzoom>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maxzoom: Option<u8>,
+
+    /// An integer representing the lowest zoom level whose tiles this layer appears in.
+    ///
+    /// minzoom MUST be greater than or equal to the set of tiles' minzoom.
+    /// See <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#334-minzoom-and-maxzoom>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minzoom: Option<u8>,
+
+    /// Any unrecognized fields will be stored here.
+    #[serde(flatten)]
+    pub other: HashMap<String, Value>,
+}
+
+impl VectorLayer {
+    pub fn new(id: String, fields: HashMap<String, String>) -> Self {
+        Self {
+            id,
+            fields,
+            description: None,
+            maxzoom: None,
+            minzoom: None,
+            other: Default::default(),
+        }
+    }
+}


### PR DESCRIPTION
* `tilejson!` solves most of the weirdness left-over from the builder pattern, and allows flexible usage (see docs)
* fix docs and add it to CI
* move structs into separate files
* implement `FromStr` for the `Bounds` and `Center` structs

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
