### PR TITLE
Make `Bounds::try_from()` more generic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
   schedule: [cron: "45 6 * * *"]
 
-env:
-  RUST_TOOLCHAIN: stable
-  TOOLCHAIN_PROFILE: default
-
 name: Run tests
 jobs:
   lints:
@@ -19,34 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
-          components: rustfmt, clippy
-      - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: actions/checkout@v3
+      - name: Install fmt & clippy
+        run: rustup component add clippy rustfmt
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
       - name: Run cargo docs
-        uses: actions-rs/cargo@v1
+        run: cargo doc --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
-        with:
-          command: doc
-          args: --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+<a name="v0.3.2"></a>
 ### Pending
-*
+* Add `Bounds::from` for `[f64; 4]`, `[f32; 4]`, `[i32; 4]`
+* Add `Bounds::try_from` now also supports `&[f64]`, `&[f32]`, `&[i32]` in addition to `Vec<f64>`
 
 <a name="v0.3.1"></a>
 ### v0.3.1 (2022-05-29)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilejson"
-version = "0.3.1"
+version = "0.3.2"
 description = "Library for serializing the TileJSON file format"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -315,7 +315,7 @@ mod tests {
         ]
     }"#;
 
-        let mut tilejson: TileJSON = serde_json::from_str(&tilejson_str).unwrap();
+        let mut tilejson: TileJSON = serde_json::from_str(tilejson_str).unwrap();
 
         assert_eq!(
             tilejson,
@@ -388,11 +388,11 @@ mod tests {
 
     #[test]
     fn test_bad_json() {
-        parse(&r#"{"tilejson":"3.0.0", "tiles":["x"], "center":[]}"#).unwrap_err();
-        parse(&r#"{"tilejson":"3.0.0", "tiles":["x"], "center":[1,2]}"#).unwrap_err();
-        parse(&r#"{"tilejson":"3.0.0", "tiles":["x"], "center":[1,2,3,4]}"#).unwrap_err();
-        parse(&r#"{"tilejson":"3.0.0", "tiles":["x"], "bounds":[]}"#).unwrap_err();
-        parse(&r#"{"tilejson":"3.0.0", "tiles":["x"], "bounds":[1,2,3]}"#).unwrap_err();
-        parse(&r#"{"tilejson":"3.0.0", "tiles":["x"], "bounds":[1,2,3,4,5]}"#).unwrap_err();
+        parse(r#"{"tilejson":"3.0.0", "tiles":["x"], "center":[]}"#).unwrap_err();
+        parse(r#"{"tilejson":"3.0.0", "tiles":["x"], "center":[1,2]}"#).unwrap_err();
+        parse(r#"{"tilejson":"3.0.0", "tiles":["x"], "center":[1,2,3,4]}"#).unwrap_err();
+        parse(r#"{"tilejson":"3.0.0", "tiles":["x"], "bounds":[]}"#).unwrap_err();
+        parse(r#"{"tilejson":"3.0.0", "tiles":["x"], "bounds":[1,2,3]}"#).unwrap_err();
+        parse(r#"{"tilejson":"3.0.0", "tiles":["x"], "bounds":[1,2,3,4,5]}"#).unwrap_err();
     }
 }


### PR DESCRIPTION
* Add `Bounds::from` for `[f64; 4]`, `[f32; 4]`, `[i32; 4]`
* Add `Bounds::try_from` now also supports `&[f64]`, `&[f32]`, `&[i32]` in addition to `Vec<f64>`
* Simplify CI scripts, reducing the number of external dependencies
* Reworked `Bounds` string parsing

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
