### PR TITLE
Add Bounds MAX, MAX_TILED, Add, AddAssign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Pending
+* Add `Bounds::MAX` to create a maximum -180..180, -90..90 value.
+* Add `Bounds::MAX_TILED` to create a maximum allowed for vector tiles per spec.
+* Implement `Add` and `AddAssign` on `Bounds` 
+
 <a name="v0.3.0"></a>
 ### v0.3.0 (2022-05-25)
 


### PR DESCRIPTION
* Add `Bounds::MAX` to create a maximum -180..180, -90..90 value.
* Add `Bounds::MAX_TILED` to create a maximum allowed for vector tiles per spec.
* Implement `Add` and `AddAssign` on `Bounds`

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
