### PR TITLE
Fix error implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<a name="v0.3.4"></a>
+### v0.3.4 (2022-11-15)
+* Add proper `Error` implementation to `Bounds` and `Center` parsing errors
+
 <a name="v0.3.3"></a>
 ### v0.3.3 (2022-11-07)
 * Add `Display` with precision support for `Bounds` and `Center` structs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilejson"
-version = "0.3.3"
+version = "0.3.4"
 description = "Library for serializing the TileJSON file format"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
@@ -19,3 +19,4 @@ categories = ["science::geo"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_tuple = "0.5"
+thiserror = "1"


### PR DESCRIPTION
Use `thiserror` to correctly implement error handling.
* Implements the missing `impl Error`
* Adds `From` for error conversion

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
