### PR TITLE
Switch HashMap to BTreeMap, lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<a name="v0.4.0"></a>
+### v0.4.0 (2022-11-19)
+* Switch all `HashMap` to `BTreeMap` for consistent serialization ordering
+
 <a name="v0.3.4"></a>
 ### v0.3.4 (2022-11-15)
 * Add proper `Error` implementation to `Bounds` and `Center` parsing errors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilejson"
-version = "0.3.4"
+version = "0.4.0"
 description = "Library for serializing the TileJSON file format"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
@@ -20,3 +20,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_tuple = "0.5"
 thiserror = "1"
+
+[lints.rust]
+unsafe_code = "forbid"
+unused_qualifications = "warn"
+
+[lints.clippy]
+pedantic = "warn"

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -87,7 +87,7 @@ impl Display for Bounds {
     /// # use std::str::FromStr;
     /// let bounds = Bounds::new(-1.5, -2.5, 3.5, 4.5);
     /// assert_eq!(bounds.to_string(), "-1.5,-2.5,3.5,4.5");
-    /// assert_eq!(format!("{:.2}", bounds), "-1.50,-2.50,3.50,4.50");
+    /// assert_eq!(format!("{bounds:.2}"), "-1.50,-2.50,3.50,4.50");
     /// assert_eq!(Bounds::from_str(&bounds.to_string()).unwrap(), bounds);
     /// ```
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -322,15 +322,9 @@ impl FromStr for Bounds {
         let mut values = s.split(',');
         let mut result = [0.; 4];
         for val in &mut result {
-            *val = values
-                .next()
-                .ok_or(ParseBoundsError::BadLen)?
-                .trim()
-                .parse()?;
+            *val = values.next().ok_or(BadLen)?.trim().parse()?;
         }
-        values
-            .next()
-            .map_or(Ok(result.into()), |_| Err(ParseBoundsError::BadLen))
+        values.next().map_or(Ok(result.into()), |_| Err(BadLen))
     }
 }
 

--- a/src/center.rs
+++ b/src/center.rs
@@ -31,7 +31,7 @@ impl Display for Center {
     /// # use std::str::FromStr;
     /// let center = Center::new(1.5, -2.5, 8);
     /// assert_eq!(center.to_string(), "1.5,-2.5,8");
-    /// assert_eq!(format!("{:.2}", center), "1.50,-2.50,8");
+    /// assert_eq!(format!("{center:.2}"), "1.50,-2.50,8");
     /// assert_eq!(Center::from_str(&center.to_string()).unwrap(), center);
     /// ```
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -204,7 +204,7 @@ pub struct TileJSON {
 
     /// Any unrecognized fields will be stored here
     #[serde(flatten)]
-    pub other: HashMap<String, Value>,
+    pub other: BTreeMap<String, Value>,
 }
 
 impl TileJSON {
@@ -354,6 +354,34 @@ mod tests {
     }
 
     #[test]
+    fn test_other() {
+        let tilejson_str = r#"{
+        "tilejson": "3.0.0",
+        "attribution": "",
+        "name": "compositing",
+        "scheme": "tms",
+        "tiles": [
+            "http://localhost:8888/foo/{z}/{x}/{y}.png"
+        ],
+        "foo": "foo value",
+        "bar": "bar value"
+    }"#;
+
+        let tilejson: TileJSON = serde_json::from_str(tilejson_str).unwrap();
+        let mut expected = tilejson! {
+            tilejson: "3.0.0".to_string(),
+            tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
+            attribution: "".to_string(),
+            name: "compositing".to_string(),
+            scheme: "tms".to_string(),
+        };
+        expected.other.insert("foo".to_string(), "foo value".into());
+        expected.other.insert("bar".to_string(), "bar value".into());
+
+        assert_eq!(tilejson, expected);
+    }
+
+    #[test]
     fn test_writing() {
         let source = "http://localhost:8888/foo/{z}/{x}/{y}.png";
         let tj = tilejson! {
@@ -371,7 +399,7 @@ mod tests {
 
         let vl = VectorLayer::new(
             "a".to_string(),
-            HashMap::from([("b".to_string(), "c".to_string())]),
+            BTreeMap::from([("b".to_string(), "c".to_string())]),
         );
         let tj = tilejson! {
             source.to_string(),

--- a/src/vector_layer.rs
+++ b/src/vector_layer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -66,7 +66,7 @@ pub struct VectorLayer {
     /// Each value (description) MUST be a string that describes the underlying data.
     /// If no fields are present, the fields key MUST be an empty object.
     /// <https://github.com/mapbox/tilejson-spec/tree/master/3.0.0#332-fields>
-    pub fields: HashMap<String, String>,
+    pub fields: BTreeMap<String, String>,
 
     /// A string representing a human-readable description of the entire layer's contents.
     ///
@@ -90,11 +90,11 @@ pub struct VectorLayer {
 
     /// Any unrecognized fields will be stored here.
     #[serde(flatten)]
-    pub other: HashMap<String, Value>,
+    pub other: BTreeMap<String, Value>,
 }
 
 impl VectorLayer {
-    pub fn new(id: String, fields: HashMap<String, String>) -> Self {
+    pub fn new(id: String, fields: BTreeMap<String, String>) -> Self {
         Self {
             id,
             fields,


### PR DESCRIPTION
* This crate is mostly needed for (de-)serialization, so keeping ordering of the output consistent is a better approach.
* Made a few tiny linting changes
* Added clippy configuration to Cargo.toml (only works on Rust 1.74+, and will be ignored by the earlier Cargo)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
