### PR TITLE
Add `Bounds::from` and `Center::from` for tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="v0.4.1"></a>
+### v0.4.1 (2022-12-08)
+* Add `Bounds::from` for `(f64, f64, f64, f64)` tuple. Same for `f32` and `i32`.
+* Add `Center::from` for `(f64, f64, u8)` and `(f32, f32, u8)` tuples.
+* A few clippy-related fixes
+
 <a name="v0.4.0"></a>
 ### v0.4.0 (2022-11-19)
 * Switch all `HashMap` to `BTreeMap` for consistent serialization ordering

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilejson"
-version = "0.4.0"
+version = "0.4.1"
 description = "Library for serializing the TileJSON file format"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",
@@ -26,4 +26,4 @@ unsafe_code = "forbid"
 unused_qualifications = "warn"
 
 [lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -18,6 +18,7 @@ pub struct Bounds {
 
 impl Bounds {
     /// Create a new Bounds object.
+    #[must_use]
     pub fn new(left: f64, bottom: f64, right: f64, top: f64) -> Self {
         Self {
             left,
@@ -58,9 +59,9 @@ impl Bounds {
     pub const MAX_TILED: Self = {
         Self {
             left: -180.0,
-            bottom: -85.05112877980659,
+            bottom: -85.051_128_779_806_59,
             right: 180.0,
-            top: 85.0511287798066,
+            top: 85.051_128_779_806_6,
         }
     };
 }
@@ -150,16 +151,16 @@ impl AddAssign for Bounds {
     /// ```
     fn add_assign(&mut self, rhs: Self) {
         if self.left > rhs.left {
-            self.left = rhs.left
+            self.left = rhs.left;
         }
         if self.bottom > rhs.bottom {
-            self.bottom = rhs.bottom
+            self.bottom = rhs.bottom;
         }
         if self.right < rhs.right {
-            self.right = rhs.right
+            self.right = rhs.right;
         }
         if self.top < rhs.top {
-            self.top = rhs.top
+            self.top = rhs.top;
         }
     }
 }
@@ -174,7 +175,7 @@ pub enum ParseBoundsError {
 }
 
 impl From<[f64; 4]> for Bounds {
-    /// Parse four f64 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -194,7 +195,7 @@ impl From<[f64; 4]> for Bounds {
 }
 
 impl From<[f32; 4]> for Bounds {
-    /// Parse four f32 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four f32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -205,16 +206,16 @@ impl From<[f32; 4]> for Bounds {
     /// ```
     fn from(value: [f32; 4]) -> Self {
         Self {
-            left: value[0] as f64,
-            bottom: value[1] as f64,
-            right: value[2] as f64,
-            top: value[3] as f64,
+            left: f64::from(value[0]),
+            bottom: f64::from(value[1]),
+            right: f64::from(value[2]),
+            top: f64::from(value[3]),
         }
     }
 }
 
 impl From<[i32; 4]> for Bounds {
-    /// Parse four i32 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four i32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -225,10 +226,70 @@ impl From<[i32; 4]> for Bounds {
     /// ```
     fn from(value: [i32; 4]) -> Self {
         Self {
-            left: value[0] as f64,
-            bottom: value[1] as f64,
-            right: value[2] as f64,
-            top: value[3] as f64,
+            left: f64::from(value[0]),
+            bottom: f64::from(value[1]),
+            right: f64::from(value[2]),
+            top: f64::from(value[3]),
+        }
+    }
+}
+
+impl From<(f64, f64, f64, f64)> for Bounds {
+    /// Parse a tuple with four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    ///
+    /// ```
+    /// # use tilejson::Bounds;
+    /// assert_eq!(
+    ///     Bounds::new(1., 2., 3., 4.),
+    ///     Bounds::from((1., 2., 3., 4.))
+    /// );
+    /// ```
+    fn from(value: (f64, f64, f64, f64)) -> Self {
+        Self {
+            left: value.0,
+            bottom: value.1,
+            right: value.2,
+            top: value.3,
+        }
+    }
+}
+
+impl From<(f32, f32, f32, f32)> for Bounds {
+    /// Parse a tuple with four f32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    ///
+    /// ```
+    /// # use tilejson::Bounds;
+    /// assert_eq!(
+    ///     Bounds::new(1., 2., 3., 4.),
+    ///     Bounds::from((1.0f32, 2.0f32, 3.0f32, 4.0f32))
+    /// );
+    /// ```
+    fn from(value: (f32, f32, f32, f32)) -> Self {
+        Self {
+            left: f64::from(value.0),
+            bottom: f64::from(value.1),
+            right: f64::from(value.2),
+            top: f64::from(value.3),
+        }
+    }
+}
+
+impl From<(i32, i32, i32, i32)> for Bounds {
+    /// Parse a tuple with four i32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    ///
+    /// ```
+    /// # use tilejson::Bounds;
+    /// assert_eq!(
+    ///     Bounds::new(1., 2., 3., 4.),
+    ///     Bounds::from((1, 2, 3, 4))
+    /// );
+    /// ```
+    fn from(value: (i32, i32, i32, i32)) -> Self {
+        Self {
+            left: f64::from(value.0),
+            bottom: f64::from(value.1),
+            right: f64::from(value.2),
+            top: f64::from(value.3),
         }
     }
 }
@@ -236,7 +297,7 @@ impl From<[i32; 4]> for Bounds {
 impl TryFrom<Vec<f64>> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four f64 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -254,7 +315,7 @@ impl TryFrom<Vec<f64>> for Bounds {
 impl TryFrom<&[f64]> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four f64 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -272,7 +333,7 @@ impl TryFrom<&[f64]> for Bounds {
 impl TryFrom<&[f32]> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four f32 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four f32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -290,7 +351,7 @@ impl TryFrom<&[f32]> for Bounds {
 impl TryFrom<&[i32]> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four i32 values as a Bounds value, same order as the [Bounds::new] constructor.
+    /// Parse four i32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -309,7 +370,7 @@ impl FromStr for Bounds {
     type Err = ParseBoundsError;
 
     /// Parse a string of four comma-separated values as a Bounds value,
-    /// same order as the [Bounds::new] constructor. Extra spaces are ignored.
+    /// same order as the [`Bounds::new`] constructor. Extra spaces are ignored.
     ///
     /// # Example
     /// ```

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -175,7 +175,7 @@ pub enum ParseBoundsError {
 }
 
 impl From<[f64; 4]> for Bounds {
-    /// Parse four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `f64` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -195,7 +195,7 @@ impl From<[f64; 4]> for Bounds {
 }
 
 impl From<[f32; 4]> for Bounds {
-    /// Parse four f32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `f32` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -215,7 +215,7 @@ impl From<[f32; 4]> for Bounds {
 }
 
 impl From<[i32; 4]> for Bounds {
-    /// Parse four i32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `i32` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -235,7 +235,7 @@ impl From<[i32; 4]> for Bounds {
 }
 
 impl From<(f64, f64, f64, f64)> for Bounds {
-    /// Parse a tuple with four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse a tuple with four `f64` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -255,7 +255,7 @@ impl From<(f64, f64, f64, f64)> for Bounds {
 }
 
 impl From<(f32, f32, f32, f32)> for Bounds {
-    /// Parse a tuple with four f32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse a tuple with four `f32` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -275,7 +275,7 @@ impl From<(f32, f32, f32, f32)> for Bounds {
 }
 
 impl From<(i32, i32, i32, i32)> for Bounds {
-    /// Parse a tuple with four i32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse a tuple with four `i32` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -297,7 +297,7 @@ impl From<(i32, i32, i32, i32)> for Bounds {
 impl TryFrom<Vec<f64>> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `f64` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -315,7 +315,7 @@ impl TryFrom<Vec<f64>> for Bounds {
 impl TryFrom<&[f64]> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four f64 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `f64` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -333,7 +333,7 @@ impl TryFrom<&[f64]> for Bounds {
 impl TryFrom<&[f32]> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four f32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `f32` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;
@@ -351,7 +351,7 @@ impl TryFrom<&[f32]> for Bounds {
 impl TryFrom<&[i32]> for Bounds {
     type Error = ParseBoundsError;
 
-    /// Parse four i32 values as a Bounds value, same order as the [`Bounds::new`] constructor.
+    /// Parse four `i32` values as a Bounds value, same order as the [`Bounds::new`] constructor.
     ///
     /// ```
     /// # use tilejson::Bounds;

--- a/src/center.rs
+++ b/src/center.rs
@@ -13,6 +13,7 @@ pub struct Center {
 }
 
 impl Center {
+    #[must_use]
     pub fn new(longitude: f64, latitude: f64, zoom: u8) -> Self {
         Self {
             longitude,
@@ -55,11 +56,49 @@ pub enum ParseCenterError {
     ParseZoomError(#[from] ParseIntError),
 }
 
+impl From<(f64, f64, u8)> for Center {
+    /// Parse a tuple as a Center value, same order as the [`Center::new`] constructor.
+    ///
+    /// ```
+    /// # use tilejson::Center;
+    /// assert_eq!(
+    ///     Center::new(1.0, 2.0, 3),
+    ///     Center::from((1.0_f64, 2.0_f64, 3))
+    /// );
+    /// ```
+    fn from(value: (f64, f64, u8)) -> Self {
+        Self {
+            longitude: value.0,
+            latitude: value.1,
+            zoom: value.2,
+        }
+    }
+}
+
+impl From<(f32, f32, u8)> for Center {
+    /// Parse a tuple as a Center value, same order as the [`Center::new`] constructor.
+    ///
+    /// ```
+    /// # use tilejson::Center;
+    /// assert_eq!(
+    ///     Center::new(1.0, 2.0, 3),
+    ///     Center::from((1.0_f32, 2.0_f32, 3))
+    /// );
+    /// ```
+    fn from(value: (f32, f32, u8)) -> Self {
+        Self {
+            longitude: f64::from(value.0),
+            latitude: f64::from(value.1),
+            zoom: value.2,
+        }
+    }
+}
+
 impl FromStr for Center {
     type Err = ParseCenterError;
 
     /// Parse a string of four comma-separated values as a Center value,
-    /// same order as the [Center::new] constructor. Extra spaces are ignored.
+    /// same order as the [`Center::new`] constructor. Extra spaces are ignored.
     ///
     /// # Example
     /// ```
@@ -68,7 +107,7 @@ impl FromStr for Center {
     /// let center = Center::from_str("1.0, 2.0, 3").unwrap();
     /// assert_eq!(center, Center::new(1.0, 2.0, 3));
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut vals = s.split(',').map(|s| s.trim());
+        let mut vals = s.split(',').map(str::trim);
         let mut next_val = || vals.next().ok_or(ParseCenterError::BadLen);
         let center = Self {
             longitude: next_val()?.parse()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-//! # TileJSON
+//! # `TileJSON`
 //!
 //! `tilejson` is a crate for serializing/deserializing
 //! [TileJSON format](https://github.com/mapbox/tilejson-spec) —
 //! an open standard for representing map metadata.
 //!
-//! Use [tilejson!] macro to instantiate a valid [TileJSON].
-//! Use [TileJSON::set_missing_defaults] to populate default values per spec.
+//! Use [`tilejson!`] macro to instantiate a valid [`TileJSON`].
+//! Use [`TileJSON::set_missing_defaults`] to populate default values per spec.
 
 mod bounds;
 mod center;

--- a/src/tilejson.rs
+++ b/src/tilejson.rs
@@ -7,7 +7,7 @@ use crate::bounds::Bounds;
 use crate::center::Center;
 use crate::vector_layer::VectorLayer;
 
-/// TileJSON struct represents tilejson-spec metadata as specified by
+/// `TileJSON` struct represents tilejson-spec metadata as specified by
 /// <https://github.com/mapbox/tilejson-spec> (version 3.0.0)
 /// Some descriptions were copied verbatim from the spec per CC-BY 3.0 license.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -218,7 +218,7 @@ impl TileJSON {
     }
 }
 
-/// Use this macro to create a TileJSON struct with optional values.
+/// Use this macro to create a `TileJSON` struct with optional values.
 /// The `tilejson!` macro can be used in several ways:
 ///
 /// ### With a single tile source
@@ -324,7 +324,7 @@ mod tests {
             tilejson! {
                 tilejson: "3.0.0".to_string(),
                 tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
-                attribution: "".to_string(),
+                attribution: String::new(),
                 name: "compositing".to_string(),
                 scheme: "tms".to_string(),
             }
@@ -337,14 +337,14 @@ mod tests {
             tilejson! {
                 tilejson: "3.0.0".to_string(),
                 tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
-                attribution: "".to_string(),
+                attribution: String::new(),
                 name: "compositing".to_string(),
                 scheme: "tms".to_string(),
                 bounds: Bounds::new(
                     -180.0,
-                    -85.05112877980659,
+                    -85.051_128_779_806_59,
                     180.0,
-                    85.0511287798066,
+                    85.051_128_779_806_6,
                 ),
                 maxzoom: 30,
                 minzoom: 0,
@@ -371,7 +371,7 @@ mod tests {
         let mut expected = tilejson! {
             tilejson: "3.0.0".to_string(),
             tiles: vec!["http://localhost:8888/foo/{z}/{x}/{y}.png".to_string()],
-            attribution: "".to_string(),
+            attribution: String::new(),
             name: "compositing".to_string(),
             scheme: "tms".to_string(),
         };

--- a/src/vector_layer.rs
+++ b/src/vector_layer.rs
@@ -5,12 +5,12 @@ use serde_json::Value;
 
 /// Each object describes one layer of vector tile data.
 ///
-/// A vector_layer object MUST contain the id and fields keys, and MAY contain the description,
+/// A `vector_layer` object MUST contain the id and fields keys, and MAY contain the description,
 /// minzoom, or maxzoom keys. An implementation MAY include arbitrary keys in the object
 /// outside of those defined in this specification.
 ///
 /// *Note: When describing a set of raster tiles or other tile format that does not have
-/// a "layers" concept (i.e. "format": "jpeg"), the vector_layers key is not required.*
+/// a "layers" concept (i.e. "format": "jpeg"), the `vector_layers` key is not required.*
 ///
 /// These keys are used to describe the situation where different sets of vector layers
 /// appear in different zoom levels of the same set of tiles, for example in a case where
@@ -94,6 +94,7 @@ pub struct VectorLayer {
 }
 
 impl VectorLayer {
+    #[must_use]
     pub fn new(id: String, fields: BTreeMap<String, String>) -> Self {
         Self {
             id,
@@ -101,7 +102,7 @@ impl VectorLayer {
             description: None,
             maxzoom: None,
             minzoom: None,
-            other: Default::default(),
+            other: BTreeMap::default(),
         }
     }
 }


### PR DESCRIPTION
* Bump to 0.4.1, ready for release
* Add `Bounds::from` for `(f64, f64, f64, f64)` tuple. Same for `f32` and `i32`.
* Add `Center::from` for `(f64, f64, u8)` and `(f32, f32, u8)` tuples.
* A few clippy-related fixes

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
