### PR TITLE
run linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ### v0.3.1 (2022-05-29)
 * Add `Bounds::MAX` to create a maximum -180..180, -90..90 value.
 * Add `Bounds::MAX_TILED` to create a maximum allowed for vector tiles per spec.
-* Implement `Add` and `AddAssign` on `Bounds` 
+* Implement `Add` and `AddAssign` on `Bounds`
 
 <a name="v0.3.0"></a>
 ### v0.3.0 (2022-05-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@
 *   use String instead of &'static str for `tilejson` field (#7) ([25b325c9](https://github.com/georust/tilejson/commit/25b325c9f0618f1cad16899385f87339ac366e20))
 
 
-
 <a name="v0.2.3"></a>
 ### v0.2.3 (2021-10-10)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ fn main() {
     // Parse JSON
     let mut tilejson: TileJSON = serde_json::from_str(&tilejson_str).unwrap();
     println!("{tilejson:?}");
-   
+
     // Add missing default values per TileJSON specification
     tilejson.set_missing_defaults();
     println!("{tilejson:?}");


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---
