### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/georust/tilejson/compare/v0.4.3...v0.4.4) - 2025-12-01
+
+### Other
+
+- add .editorconfig
+- minor justfile adjustments
+- minor justfile adjustments
+- use automatic crates.io token ([#43](https://github.com/georust/tilejson/pull/43))
+- Change test attribute from expect to allow for MSRV ([#42](https://github.com/georust/tilejson/pull/42))
+- add more linting
+- *(just)* minor justfile cleanup
+- *(ci)* improve cargo-install recipe
+- *(ci)* disable telemetry in workflow
+- format Cargo.toml, minor just cleanup ([#40](https://github.com/georust/tilejson/pull/40))
+- [pre-commit.ci] pre-commit autoupdate ([#38](https://github.com/georust/tilejson/pull/38))
+- Bump actions/checkout from 4 to 5 in the all-actions-version-updates group ([#39](https://github.com/georust/tilejson/pull/39))
+
 ## [0.4.3](https://github.com/georust/tilejson/compare/v0.4.2...v0.4.3) - 2025-06-16
 - migrate to release-plz CI and rework CI/dependabot pipeline ([#43](https://github.com/georust/tilejson/pull/43), [#36](https://github.com/georust/tilejson/pull/36), [#35](https://github.com/georust/tilejson/pull/35), [#33](https://github.com/georust/tilejson/pull/33), [#32](https://github.com/georust/tilejson/pull/32), [#31](https://github.com/georust/tilejson/pull/31), [#30](https://github.com/georust/tilejson/pull/30))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilejson"
-version = "0.4.3"
+version = "0.4.4"
 description = "Library for serializing the TileJSON file format"
 authors = [
     "Stepan Kuzmin <to.stepan.kuzmin@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `tilejson`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/georust/tilejson/compare/v0.4.3...v0.4.4) - 2025-12-01

### Other

- add .editorconfig
- minor justfile adjustments
- minor justfile adjustments
- use automatic crates.io token ([#43](https://github.com/georust/tilejson/pull/43))
- Change test attribute from expect to allow for MSRV ([#42](https://github.com/georust/tilejson/pull/42))
- add more linting
- *(just)* minor justfile cleanup
- *(ci)* improve cargo-install recipe
- *(ci)* disable telemetry in workflow
- format Cargo.toml, minor just cleanup ([#40](https://github.com/georust/tilejson/pull/40))
- [pre-commit.ci] pre-commit autoupdate ([#38](https://github.com/georust/tilejson/pull/38))
- Bump actions/checkout from 4 to 5 in the all-actions-version-updates group ([#39](https://github.com/georust/tilejson/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).